### PR TITLE
feat: Add settings screen with default values and address format options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,15 +144,18 @@ JustAMap/
 │   ├── LocationManager.swift
 │   ├── LocationManagerProtocol.swift
 │   ├── AddressFormatter.swift
+│   ├── AddressFormat.swift
 │   ├── MapViewModel.swift
-│   └── MapControlsViewModel.swift
+│   ├── MapControlsViewModel.swift
+│   └── SettingsViewModel.swift
 ├── Services/
 │   ├── GeocodeService.swift
 │   ├── IdleTimerManager.swift
 │   └── MapSettingsStorage.swift
 ├── Views/
 │   ├── AddressView.swift
-│   └── MapControlsView.swift
+│   ├── MapControlsView.swift
+│   └── SettingsView.swift
 ├── Extensions/
 │   └── (現在は空)
 └── Assets.xcassets/
@@ -166,6 +169,7 @@ JustAMapTests/
 ├── IdleTimerManagerTests.swift
 ├── MapControlsViewModelTests.swift
 ├── MapSettingsStorageTests.swift
+├── SettingsViewModelTests.swift
 └── TestDoubles/
     └── MockLocationManager.swift
 
@@ -285,6 +289,8 @@ let testScenarios = [
 ### データ永続化
 - **保存対象**: 
   - UI設定（ズームインデックス、地図スタイル、地図の向き）
+  - デフォルト設定（デフォルトズームレベル、デフォルト地図スタイル、デフォルト地図の向き）
+  - 住所表示フォーマット設定
 - **保存しない**: 
   - 位置情報（緯度経度）
   - 移動履歴
@@ -306,12 +312,6 @@ let testScenarios = [
 ### 多言語化
 - 日本語に加えて、英語 ([Issue #2](https://github.com/skoji/just-a-map/issues/2))
 
-### 設定画面
-- デフォルトズームレベル
-- 地図の種類の初期設定
-- 住所表示のフォーマット選択
-- ([Issue #3](https://github.com/skoji/just-a-map/issues/3))
-
 ### 音声操作
 - 「ズームイン/アウト」
 - 「ノースアップ/ヘディングアップ」
@@ -325,6 +325,12 @@ let testScenarios = [
 ## 実装済み機能
 
 > **記録形式**: 機能名 (実装日: YYYY-MM-DD, PR: #番号)
+
+### 設定画面
+- デフォルトズームレベル、地図の種類、地図の向きの設定
+- 住所表示フォーマット選択（標準、詳細、シンプル）
+- 設定の永続化とアプリ起動時の適用
+- (実装日: 2025-01-06, PR: #7, [Issue #3](https://github.com/skoji/just-a-map/issues/3))
 
 ## 参考リソース
 - [Apple MapKit Documentation](https://developer.apple.com/documentation/mapkit/)

--- a/JustAMap/MapView.swift
+++ b/JustAMap/MapView.swift
@@ -98,6 +98,7 @@ struct MapView: View {
                             .clipShape(Circle())
                             .shadow(radius: 2)
                     }
+                    .accessibilityLabel("設定")
                     .padding(.trailing, 20)
                     .padding(.top, 10)
                 }

--- a/JustAMap/MapView.swift
+++ b/JustAMap/MapView.swift
@@ -201,6 +201,10 @@ struct MapView: View {
         }
         .sheet(isPresented: $isShowingSettings) {
             SettingsView()
+                .onDisappear {
+                    // 設定画面が閉じられたときに住所フォーマットを更新
+                    viewModel.refreshAddressFormat()
+                }
         }
     }
 }

--- a/JustAMap/MapView.swift
+++ b/JustAMap/MapView.swift
@@ -13,6 +13,7 @@ struct MapView: View {
     )
     @State private var currentMapCamera: MapCamera?
     @State private var isZoomingByButton = false
+    @State private var isShowingSettings = false
     
     var body: some View {
         ZStack {
@@ -76,11 +77,30 @@ struct MapView: View {
             
             // 上部のUI（住所表示とエラー表示）
             VStack {
-                // 住所表示
-                AddressView(
-                    formattedAddress: viewModel.formattedAddress,
-                    isLoading: viewModel.isLoadingAddress
-                )
+                // 住所表示と設定ボタン
+                HStack(alignment: .top) {
+                    AddressView(
+                        formattedAddress: viewModel.formattedAddress,
+                        isLoading: viewModel.isLoadingAddress
+                    )
+                    
+                    Spacer()
+                    
+                    // 設定ボタン
+                    Button(action: {
+                        isShowingSettings = true
+                    }) {
+                        Image(systemName: "gear")
+                            .font(.title2)
+                            .foregroundColor(.blue)
+                            .frame(width: 44, height: 44)
+                            .background(Color(.systemBackground))
+                            .clipShape(Circle())
+                            .shadow(radius: 2)
+                    }
+                    .padding(.trailing, 20)
+                    .padding(.top, 10)
+                }
                 
                 // エラー表示
                 if let error = viewModel.locationError {
@@ -177,6 +197,9 @@ struct MapView: View {
         }
         .onReceive(viewModel.mapControlsViewModel.$currentZoomIndex) { _ in
             viewModel.saveSettings()
+        }
+        .sheet(isPresented: $isShowingSettings) {
+            SettingsView()
         }
     }
 }

--- a/JustAMap/Models/AddressFormat.swift
+++ b/JustAMap/Models/AddressFormat.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum AddressFormat: String, CaseIterable {
+    case standard = "standard"
+    case detailed = "detailed"
+    case simple = "simple"
+    
+    var displayName: String {
+        switch self {
+        case .standard:
+            return "標準"
+        case .detailed:
+            return "詳細"
+        case .simple:
+            return "シンプル"
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .standard:
+            return "場所名または市区町村を表示"
+        case .detailed:
+            return "完全な住所を常に表示"
+        case .simple:
+            return "市区町村のみを表示"
+        }
+    }
+}

--- a/JustAMap/Models/AddressFormatter.swift
+++ b/JustAMap/Models/AddressFormatter.swift
@@ -85,12 +85,29 @@ class AddressFormatter {
     private func buildDetailedSecondaryText(from address: Address) -> String {
         var components: [String] = []
         
+        // 場所名
         if let name = address.name, !name.isEmpty {
             components.append(name)
         }
         
+        // 市区町村
+        if let locality = address.locality, !locality.isEmpty {
+            components.append(locality)
+        }
+        
+        // 郡・地区
         if let subAdministrativeArea = address.subAdministrativeArea, !subAdministrativeArea.isEmpty {
             components.append(subAdministrativeArea)
+        }
+        
+        // 都道府県
+        if let administrativeArea = address.administrativeArea, !administrativeArea.isEmpty {
+            components.append(administrativeArea)
+        }
+        
+        // 国
+        if let country = address.country, !country.isEmpty {
+            components.append(country)
         }
         
         return components.joined(separator: " / ")

--- a/JustAMap/Models/MapControlsViewModel.swift
+++ b/JustAMap/Models/MapControlsViewModel.swift
@@ -7,6 +7,10 @@ enum MapStyle: String, CaseIterable {
     case standard = "標準"
     case hybrid = "航空写真+地図"
     case imagery = "航空写真"
+    
+    var displayName: String {
+        return self.rawValue
+    }
 }
 
 /// 地図コントロールのビジネスロジックを管理

--- a/JustAMap/Models/MapControlsViewModel.swift
+++ b/JustAMap/Models/MapControlsViewModel.swift
@@ -16,7 +16,9 @@ enum MapStyle: String, CaseIterable {
 /// ズームレベルの定数
 enum ZoomConstants {
     static let minIndex = 0
-    static let maxIndex = 11
+    // 将来的にpredefinedAltitudesの数が変わっても対応できるように
+    // 本来は配列のサイズから動的に計算したいが、staticプロパティの制約により固定値
+    static let maxIndex = 11  // predefinedAltitudes.count - 1
 }
 
 /// 地図コントロールのビジネスロジックを管理

--- a/JustAMap/Models/MapControlsViewModel.swift
+++ b/JustAMap/Models/MapControlsViewModel.swift
@@ -13,6 +13,12 @@ enum MapStyle: String, CaseIterable {
     }
 }
 
+/// ズームレベルの定数
+enum ZoomConstants {
+    static let minIndex = 0
+    static let maxIndex = 11
+}
+
 /// 地図コントロールのビジネスロジックを管理
 @MainActor
 class MapControlsViewModel: ObservableObject {
@@ -34,6 +40,7 @@ class MapControlsViewModel: ObservableObject {
         500000,   // 大陸レベル
         1000000,  // 最大ズームアウト - 地球レベル
     ]
+    
     
     /// 現在のズームレベルインデックス
     @Published private(set) var currentZoomIndex: Int = 5 // デフォルトは市レベル
@@ -62,14 +69,14 @@ class MapControlsViewModel: ObservableObject {
     
     /// ズームイン
     func zoomIn() {
-        if currentZoomIndex > 0 {
+        if currentZoomIndex > ZoomConstants.minIndex {
             currentZoomIndex -= 1
         }
     }
     
     /// ズームアウト
     func zoomOut() {
-        if currentZoomIndex < predefinedAltitudes.count - 1 {
+        if currentZoomIndex < ZoomConstants.maxIndex {
             currentZoomIndex += 1
         }
     }

--- a/JustAMap/Models/MapViewModel.swift
+++ b/JustAMap/Models/MapViewModel.swift
@@ -52,12 +52,27 @@ class MapViewModel: ObservableObject {
     }
     
     private func loadSettings() {
-        mapControlsViewModel.currentMapStyle = settingsStorage.loadMapStyle()
-        mapControlsViewModel.isNorthUp = settingsStorage.loadMapOrientation()
+        // 現在の設定を読み込む（なければデフォルト設定を使用）
+        let currentMapStyle = settingsStorage.mapStyle
+        let currentIsNorthUp = settingsStorage.isNorthUp
+        let currentZoomIndex = settingsStorage.zoomIndex
         
-        // 保存されたズームレベルインデックスを読み込む
-        if let savedZoomIndex = settingsStorage.loadZoomIndex() {
-            mapControlsViewModel.setZoomIndex(savedZoomIndex)
+        // 保存された現在の設定がない場合は、デフォルト設定を使用
+        if settingsStorage.loadMapStyle() == .standard && 
+           settingsStorage.loadMapOrientation() == true && 
+           settingsStorage.loadZoomIndex() == nil {
+            // 初回起動時：デフォルト設定を現在の設定として保存
+            mapControlsViewModel.currentMapStyle = settingsStorage.defaultMapStyle
+            mapControlsViewModel.isNorthUp = settingsStorage.defaultIsNorthUp
+            mapControlsViewModel.setZoomIndex(settingsStorage.defaultZoomIndex)
+            
+            // 現在の設定として保存
+            saveSettings()
+        } else {
+            // 保存された設定を読み込む
+            mapControlsViewModel.currentMapStyle = currentMapStyle
+            mapControlsViewModel.isNorthUp = currentIsNorthUp
+            mapControlsViewModel.setZoomIndex(currentZoomIndex)
         }
     }
     

--- a/JustAMap/Models/MapViewModel.swift
+++ b/JustAMap/Models/MapViewModel.swift
@@ -52,16 +52,8 @@ class MapViewModel: ObservableObject {
     }
     
     private func loadSettings() {
-        // 現在の設定を読み込む（なければデフォルト設定を使用）
-        let currentMapStyle = settingsStorage.mapStyle
-        let currentIsNorthUp = settingsStorage.isNorthUp
-        let currentZoomIndex = settingsStorage.zoomIndex
-        
-        // 保存された現在の設定がない場合は、デフォルト設定を使用
-        if settingsStorage.loadMapStyle() == .standard && 
-           settingsStorage.loadMapOrientation() == true && 
-           settingsStorage.loadZoomIndex() == nil {
-            // 初回起動時：デフォルト設定を現在の設定として保存
+        if settingsStorage.isFirstLaunch() {
+            // 初回起動時：デフォルト設定を現在の設定として使用・保存
             mapControlsViewModel.currentMapStyle = settingsStorage.defaultMapStyle
             mapControlsViewModel.isNorthUp = settingsStorage.defaultIsNorthUp
             mapControlsViewModel.setZoomIndex(settingsStorage.defaultZoomIndex)
@@ -70,9 +62,9 @@ class MapViewModel: ObservableObject {
             saveSettings()
         } else {
             // 保存された設定を読み込む
-            mapControlsViewModel.currentMapStyle = currentMapStyle
-            mapControlsViewModel.isNorthUp = currentIsNorthUp
-            mapControlsViewModel.setZoomIndex(currentZoomIndex)
+            mapControlsViewModel.currentMapStyle = settingsStorage.mapStyle
+            mapControlsViewModel.isNorthUp = settingsStorage.isNorthUp
+            mapControlsViewModel.setZoomIndex(settingsStorage.zoomIndex)
         }
     }
     

--- a/JustAMap/Models/SettingsViewModel.swift
+++ b/JustAMap/Models/SettingsViewModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftUI
+
+class SettingsViewModel: ObservableObject {
+    private var settingsStorage: MapSettingsStorageProtocol
+    
+    @Published var defaultZoomIndex: Int {
+        didSet {
+            settingsStorage.defaultZoomIndex = defaultZoomIndex
+        }
+    }
+    
+    @Published var defaultMapStyle: MapStyle {
+        didSet {
+            settingsStorage.defaultMapStyle = defaultMapStyle
+        }
+    }
+    
+    @Published var defaultIsNorthUp: Bool {
+        didSet {
+            settingsStorage.defaultIsNorthUp = defaultIsNorthUp
+        }
+    }
+    
+    @Published var addressFormat: AddressFormat {
+        didSet {
+            settingsStorage.addressFormat = addressFormat
+        }
+    }
+    
+    init(settingsStorage: MapSettingsStorageProtocol = MapSettingsStorage()) {
+        self.settingsStorage = settingsStorage
+        self.defaultZoomIndex = settingsStorage.defaultZoomIndex
+        self.defaultMapStyle = settingsStorage.defaultMapStyle
+        self.defaultIsNorthUp = settingsStorage.defaultIsNorthUp
+        self.addressFormat = settingsStorage.addressFormat
+    }
+    
+    var zoomLevelDisplayText: String {
+        let zoomLevels: [String] = [
+            "200m", "500m", "1km", "2km", "5km", "10km",
+            "20km", "50km", "100km", "200km", "500km", "1,000km"
+        ]
+        
+        guard defaultZoomIndex >= 0 && defaultZoomIndex < zoomLevels.count else {
+            return zoomLevels[5] // デフォルト
+        }
+        
+        return zoomLevels[defaultZoomIndex]
+    }
+}

--- a/JustAMap/Models/SettingsViewModel.swift
+++ b/JustAMap/Models/SettingsViewModel.swift
@@ -4,6 +4,10 @@ import SwiftUI
 class SettingsViewModel: ObservableObject {
     private var settingsStorage: MapSettingsStorageProtocol
     
+    // ズームインデックスの範囲
+    static let minZoomIndex = ZoomConstants.minIndex
+    static let maxZoomIndex = ZoomConstants.maxIndex
+    
     @Published var defaultZoomIndex: Int {
         didSet {
             settingsStorage.defaultZoomIndex = defaultZoomIndex

--- a/JustAMap/Models/SettingsViewModel.swift
+++ b/JustAMap/Models/SettingsViewModel.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SwiftUI
+import Combine
 
 class SettingsViewModel: ObservableObject {
     private var settingsStorage: MapSettingsStorageProtocol

--- a/JustAMap/Services/GeocodeService.swift
+++ b/JustAMap/Services/GeocodeService.swift
@@ -25,6 +25,7 @@ struct Address: Equatable {
     let fullAddress: String
     let postalCode: String?
     let locality: String?         // 市区町村
+    let subAdministrativeArea: String? // 郡・地区
     let administrativeArea: String? // 都道府県
     let country: String?
 }
@@ -66,6 +67,7 @@ class GeocodeService: GeocodeServiceProtocol {
                 fullAddress: fullAddress,
                 postalCode: placemark.postalCode,
                 locality: placemark.locality,
+                subAdministrativeArea: placemark.subAdministrativeArea,
                 administrativeArea: placemark.administrativeArea,
                 country: placemark.country
             )

--- a/JustAMap/Services/MapSettingsStorage.swift
+++ b/JustAMap/Services/MapSettingsStorage.swift
@@ -16,6 +16,18 @@ extension UserDefaults: UserDefaultsProtocol {}
 
 /// 地図設定の永続化を管理するプロトコル
 protocol MapSettingsStorageProtocol {
+    // 現在の設定
+    var mapStyle: MapStyle { get set }
+    var isNorthUp: Bool { get set }
+    var zoomIndex: Int { get set }
+    
+    // デフォルト設定
+    var defaultZoomIndex: Int { get set }
+    var defaultMapStyle: MapStyle { get set }
+    var defaultIsNorthUp: Bool { get set }
+    var addressFormat: AddressFormat { get set }
+    
+    // 従来のメソッド（互換性のため維持）
     func saveMapStyle(_ style: MapStyle)
     func loadMapStyle() -> MapStyle
     func saveMapOrientation(isNorthUp: Bool)
@@ -37,10 +49,81 @@ class MapSettingsStorage: MapSettingsStorageProtocol {
         static let zoomLatDelta = "zoomLatDelta"
         static let zoomLonDelta = "zoomLonDelta"
         static let zoomIndex = "zoomIndex"
+        static let defaultZoomIndex = "defaultZoomIndex"
+        static let defaultMapStyle = "defaultMapStyle"
+        static let defaultIsNorthUp = "defaultIsNorthUp"
+        static let addressFormat = "addressFormat"
     }
     
     init(userDefaults: UserDefaultsProtocol = UserDefaults.standard) {
         self.userDefaults = userDefaults
+    }
+    
+    // MARK: - Computed Properties for Protocol Conformance
+    
+    var mapStyle: MapStyle {
+        get { loadMapStyle() }
+        set { saveMapStyle(newValue) }
+    }
+    
+    var isNorthUp: Bool {
+        get { loadMapOrientation() }
+        set { saveMapOrientation(isNorthUp: newValue) }
+    }
+    
+    var zoomIndex: Int {
+        get { loadZoomIndex() ?? 5 }
+        set { saveZoomIndex(newValue) }
+    }
+    
+    var defaultZoomIndex: Int {
+        get {
+            if userDefaults.object(forKey: Keys.defaultZoomIndex) != nil {
+                return userDefaults.integer(forKey: Keys.defaultZoomIndex)
+            }
+            return 5 // デフォルト値
+        }
+        set {
+            userDefaults.set(newValue, forKey: Keys.defaultZoomIndex)
+        }
+    }
+    
+    var defaultMapStyle: MapStyle {
+        get {
+            guard let rawValue = userDefaults.string(forKey: Keys.defaultMapStyle),
+                  let style = MapStyle(rawValue: rawValue) else {
+                return .standard // デフォルト
+            }
+            return style
+        }
+        set {
+            userDefaults.set(newValue.rawValue, forKey: Keys.defaultMapStyle)
+        }
+    }
+    
+    var defaultIsNorthUp: Bool {
+        get {
+            if userDefaults.object(forKey: Keys.defaultIsNorthUp) != nil {
+                return userDefaults.bool(forKey: Keys.defaultIsNorthUp)
+            }
+            return true // デフォルトはNorth Up
+        }
+        set {
+            userDefaults.set(newValue, forKey: Keys.defaultIsNorthUp)
+        }
+    }
+    
+    var addressFormat: AddressFormat {
+        get {
+            guard let rawValue = userDefaults.string(forKey: Keys.addressFormat),
+                  let format = AddressFormat(rawValue: rawValue) else {
+                return .standard // デフォルト
+            }
+            return format
+        }
+        set {
+            userDefaults.set(newValue.rawValue, forKey: Keys.addressFormat)
+        }
     }
     
     // MARK: - Map Style

--- a/JustAMap/Services/MapSettingsStorage.swift
+++ b/JustAMap/Services/MapSettingsStorage.swift
@@ -36,6 +36,9 @@ protocol MapSettingsStorageProtocol {
     func loadZoomLevel() -> MKCoordinateSpan?
     func saveZoomIndex(_ index: Int)
     func loadZoomIndex() -> Int?
+    
+    // 初回起動チェック
+    func isFirstLaunch() -> Bool
 }
 
 /// 地図設定の永続化サービス
@@ -188,5 +191,14 @@ class MapSettingsStorage: MapSettingsStorageProtocol {
             return userDefaults.integer(forKey: Keys.zoomIndex)
         }
         return nil
+    }
+    
+    // MARK: - First Launch Check
+    
+    func isFirstLaunch() -> Bool {
+        // いずれかの現在の設定が保存されていない場合は初回起動と判定
+        return userDefaults.object(forKey: Keys.mapStyle) == nil &&
+               userDefaults.object(forKey: Keys.isNorthUp) == nil &&
+               userDefaults.object(forKey: Keys.zoomIndex) == nil
     }
 }

--- a/JustAMap/Views/SettingsView.swift
+++ b/JustAMap/Views/SettingsView.swift
@@ -48,7 +48,7 @@ struct SettingsView: View {
                     
                     // 地図の種類
                     Picker("地図の種類", selection: $viewModel.defaultMapStyle) {
-                        ForEach([MapStyle.standard, .hybrid, .imagery], id: \.self) { style in
+                        ForEach(MapStyle.allCases, id: \.self) { style in
                             Text(style.displayName).tag(style)
                         }
                     }

--- a/JustAMap/Views/SettingsView.swift
+++ b/JustAMap/Views/SettingsView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @StateObject private var viewModel = SettingsViewModel()
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("デフォルト設定") {
+                    // ズームレベル
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("デフォルトズームレベル")
+                            .font(.headline)
+                        HStack {
+                            Button {
+                                if viewModel.defaultZoomIndex > 0 {
+                                    viewModel.defaultZoomIndex -= 1
+                                }
+                            } label: {
+                                Image(systemName: "minus.circle.fill")
+                                    .font(.title2)
+                                    .foregroundColor(viewModel.defaultZoomIndex > 0 ? .blue : .gray)
+                            }
+                            .disabled(viewModel.defaultZoomIndex <= 0)
+                            
+                            Spacer()
+                            
+                            Text(viewModel.zoomLevelDisplayText)
+                                .font(.title3)
+                                .frame(minWidth: 100)
+                            
+                            Spacer()
+                            
+                            Button {
+                                if viewModel.defaultZoomIndex < 11 {
+                                    viewModel.defaultZoomIndex += 1
+                                }
+                            } label: {
+                                Image(systemName: "plus.circle.fill")
+                                    .font(.title2)
+                                    .foregroundColor(viewModel.defaultZoomIndex < 11 ? .blue : .gray)
+                            }
+                            .disabled(viewModel.defaultZoomIndex >= 11)
+                        }
+                    }
+                    .padding(.vertical, 8)
+                    
+                    // 地図の種類
+                    Picker("地図の種類", selection: $viewModel.defaultMapStyle) {
+                        ForEach([MapStyle.standard, .hybrid, .imagery], id: \.self) { style in
+                            Text(style.displayName).tag(style)
+                        }
+                    }
+                    
+                    // 地図の向き
+                    Toggle("デフォルトでNorth Up", isOn: $viewModel.defaultIsNorthUp)
+                }
+                
+                Section("表示設定") {
+                    // 住所表示フォーマット
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("住所表示フォーマット")
+                            .font(.headline)
+                        
+                        ForEach(AddressFormat.allCases, id: \.self) { format in
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(format.displayName)
+                                        .font(.body)
+                                    Text(format.description)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                if viewModel.addressFormat == format {
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.blue)
+                                }
+                            }
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                viewModel.addressFormat = format
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("設定")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("閉じる") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/JustAMap/Views/SettingsView.swift
+++ b/JustAMap/Views/SettingsView.swift
@@ -14,15 +14,15 @@ struct SettingsView: View {
                             .font(.headline)
                         HStack {
                             Button {
-                                if viewModel.defaultZoomIndex > 0 {
+                                if viewModel.defaultZoomIndex > SettingsViewModel.minZoomIndex {
                                     viewModel.defaultZoomIndex -= 1
                                 }
                             } label: {
                                 Image(systemName: "minus.circle.fill")
                                     .font(.title2)
-                                    .foregroundColor(viewModel.defaultZoomIndex > 0 ? .blue : .gray)
+                                    .foregroundColor(viewModel.defaultZoomIndex > SettingsViewModel.minZoomIndex ? .blue : .gray)
                             }
-                            .disabled(viewModel.defaultZoomIndex <= 0)
+                            .disabled(viewModel.defaultZoomIndex <= SettingsViewModel.minZoomIndex)
                             
                             Spacer()
                             
@@ -33,15 +33,15 @@ struct SettingsView: View {
                             Spacer()
                             
                             Button {
-                                if viewModel.defaultZoomIndex < 11 {
+                                if viewModel.defaultZoomIndex < SettingsViewModel.maxZoomIndex {
                                     viewModel.defaultZoomIndex += 1
                                 }
                             } label: {
                                 Image(systemName: "plus.circle.fill")
                                     .font(.title2)
-                                    .foregroundColor(viewModel.defaultZoomIndex < 11 ? .blue : .gray)
+                                    .foregroundColor(viewModel.defaultZoomIndex < SettingsViewModel.maxZoomIndex ? .blue : .gray)
                             }
-                            .disabled(viewModel.defaultZoomIndex >= 11)
+                            .disabled(viewModel.defaultZoomIndex >= SettingsViewModel.maxZoomIndex)
                         }
                     }
                     .padding(.vertical, 8)

--- a/JustAMapTests/AddressFormatterTests.swift
+++ b/JustAMapTests/AddressFormatterTests.swift
@@ -21,6 +21,7 @@ final class AddressFormatterTests: XCTestCase {
             fullAddress: "東京都千代田区丸の内1-9-1",
             postalCode: "100-0005",
             locality: "千代田区",
+            subAdministrativeArea: nil,
             administrativeArea: "東京都",
             country: "日本"
         )
@@ -41,6 +42,7 @@ final class AddressFormatterTests: XCTestCase {
             fullAddress: "東京都千代田区丸の内1-9-1",
             postalCode: "100-0005",
             locality: "千代田区",
+            subAdministrativeArea: nil,
             administrativeArea: "東京都",
             country: "日本"
         )
@@ -60,6 +62,7 @@ final class AddressFormatterTests: XCTestCase {
             fullAddress: "東京都千代田区丸の内1-9-1",
             postalCode: nil,
             locality: "千代田区",
+            subAdministrativeArea: nil,
             administrativeArea: "東京都",
             country: "日本"
         )
@@ -78,6 +81,7 @@ final class AddressFormatterTests: XCTestCase {
             fullAddress: "不明な場所",
             postalCode: nil,
             locality: nil,
+            subAdministrativeArea: nil,
             administrativeArea: nil,
             country: nil
         )

--- a/JustAMapTests/MapSettingsStorageTests.swift
+++ b/JustAMapTests/MapSettingsStorageTests.swift
@@ -148,6 +148,96 @@ final class MapSettingsStorageTests: XCTestCase {
         // Then
         XCTAssertNil(index)
     }
+    
+    // MARK: - New Settings Tests
+    
+    func testDefaultZoomIndex() {
+        // Given
+        let newValue = 8
+        
+        // When
+        sut.defaultZoomIndex = newValue
+        
+        // Then
+        XCTAssertEqual(mockUserDefaults.storage["defaultZoomIndex"] as? Int, newValue)
+        XCTAssertEqual(sut.defaultZoomIndex, newValue)
+    }
+    
+    func testDefaultZoomIndexDefaultValue() {
+        // Given - UserDefaultsに何も保存されていない
+        
+        // When
+        let value = sut.defaultZoomIndex
+        
+        // Then
+        XCTAssertEqual(value, 5) // デフォルト値
+    }
+    
+    func testDefaultMapStyle() {
+        // Given
+        let newValue = MapStyle.hybrid
+        
+        // When
+        sut.defaultMapStyle = newValue
+        
+        // Then
+        XCTAssertEqual(mockUserDefaults.storage["defaultMapStyle"] as? String, newValue.rawValue)
+        XCTAssertEqual(sut.defaultMapStyle, newValue)
+    }
+    
+    func testDefaultMapStyleDefaultValue() {
+        // Given - UserDefaultsに何も保存されていない
+        
+        // When
+        let value = sut.defaultMapStyle
+        
+        // Then
+        XCTAssertEqual(value, .standard) // デフォルト値
+    }
+    
+    func testDefaultIsNorthUp() {
+        // Given
+        let newValue = false
+        
+        // When
+        sut.defaultIsNorthUp = newValue
+        
+        // Then
+        XCTAssertEqual(mockUserDefaults.storage["defaultIsNorthUp"] as? Bool, newValue)
+        XCTAssertEqual(sut.defaultIsNorthUp, newValue)
+    }
+    
+    func testDefaultIsNorthUpDefaultValue() {
+        // Given - UserDefaultsに何も保存されていない
+        
+        // When
+        let value = sut.defaultIsNorthUp
+        
+        // Then
+        XCTAssertTrue(value) // デフォルトはNorth Up
+    }
+    
+    func testAddressFormat() {
+        // Given
+        let newValue = AddressFormat.detailed
+        
+        // When
+        sut.addressFormat = newValue
+        
+        // Then
+        XCTAssertEqual(mockUserDefaults.storage["addressFormat"] as? String, newValue.rawValue)
+        XCTAssertEqual(sut.addressFormat, newValue)
+    }
+    
+    func testAddressFormatDefaultValue() {
+        // Given - UserDefaultsに何も保存されていない
+        
+        // When
+        let value = sut.addressFormat
+        
+        // Then
+        XCTAssertEqual(value, .standard) // デフォルト値
+    }
 }
 
 // MARK: - Mock UserDefaults

--- a/JustAMapTests/MapSettingsStorageTests.swift
+++ b/JustAMapTests/MapSettingsStorageTests.swift
@@ -238,6 +238,42 @@ final class MapSettingsStorageTests: XCTestCase {
         // Then
         XCTAssertEqual(value, .standard) // デフォルト値
     }
+    
+    // MARK: - First Launch Tests
+    
+    func testIsFirstLaunchReturnsTrueWhenNoSettingsSaved() {
+        // Given - UserDefaultsに何も保存されていない
+        
+        // When
+        let isFirstLaunch = sut.isFirstLaunch()
+        
+        // Then
+        XCTAssertTrue(isFirstLaunch)
+    }
+    
+    func testIsFirstLaunchReturnsFalseWhenAnySettingSaved() {
+        // Given - いずれかの設定が保存されている
+        mockUserDefaults.storage["mapStyle"] = MapStyle.standard.rawValue
+        
+        // When
+        let isFirstLaunch = sut.isFirstLaunch()
+        
+        // Then
+        XCTAssertFalse(isFirstLaunch)
+    }
+    
+    func testIsFirstLaunchReturnsFalseWhenAllSettingsSaved() {
+        // Given - すべての設定が保存されている
+        mockUserDefaults.storage["mapStyle"] = MapStyle.hybrid.rawValue
+        mockUserDefaults.storage["isNorthUp"] = false
+        mockUserDefaults.storage["zoomIndex"] = 7
+        
+        // When
+        let isFirstLaunch = sut.isFirstLaunch()
+        
+        // Then
+        XCTAssertFalse(isFirstLaunch)
+    }
 }
 
 // MARK: - Mock UserDefaults

--- a/JustAMapTests/SettingsViewModelTests.swift
+++ b/JustAMapTests/SettingsViewModelTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import JustAMap
+
+final class SettingsViewModelTests: XCTestCase {
+    var sut: SettingsViewModel!
+    var mockSettingsStorage: MockMapSettingsStorage!
+    
+    override func setUp() {
+        super.setUp()
+        mockSettingsStorage = MockMapSettingsStorage()
+        sut = SettingsViewModel(settingsStorage: mockSettingsStorage)
+    }
+    
+    override func tearDown() {
+        sut = nil
+        mockSettingsStorage = nil
+        super.tearDown()
+    }
+    
+    func testInitialValues() {
+        XCTAssertEqual(sut.defaultZoomIndex, mockSettingsStorage.defaultZoomIndex)
+        XCTAssertEqual(sut.defaultMapStyle, mockSettingsStorage.defaultMapStyle)
+        XCTAssertEqual(sut.defaultIsNorthUp, mockSettingsStorage.defaultIsNorthUp)
+        XCTAssertEqual(sut.addressFormat, mockSettingsStorage.addressFormat)
+    }
+    
+    func testUpdateDefaultZoomIndex() {
+        let newZoomIndex = 5
+        sut.defaultZoomIndex = newZoomIndex
+        
+        XCTAssertEqual(mockSettingsStorage.defaultZoomIndex, newZoomIndex)
+    }
+    
+    func testUpdateDefaultMapStyle() {
+        let newMapStyle = MapStyle.hybrid
+        sut.defaultMapStyle = newMapStyle
+        
+        XCTAssertEqual(mockSettingsStorage.defaultMapStyle, newMapStyle)
+    }
+    
+    func testUpdateDefaultIsNorthUp() {
+        let newIsNorthUp = false
+        sut.defaultIsNorthUp = newIsNorthUp
+        
+        XCTAssertEqual(mockSettingsStorage.defaultIsNorthUp, newIsNorthUp)
+    }
+    
+    func testUpdateAddressFormat() {
+        let newFormat = AddressFormat.detailed
+        sut.addressFormat = newFormat
+        
+        XCTAssertEqual(mockSettingsStorage.addressFormat, newFormat)
+    }
+    
+    func testZoomLevelDisplayText() {
+        sut.defaultZoomIndex = 0
+        XCTAssertEqual(sut.zoomLevelDisplayText, "200m")
+        
+        sut.defaultZoomIndex = 6
+        XCTAssertEqual(sut.zoomLevelDisplayText, "20km")
+        
+        sut.defaultZoomIndex = 11
+        XCTAssertEqual(sut.zoomLevelDisplayText, "1,000km")
+    }
+}
+
+class MockMapSettingsStorage: MapSettingsStorageProtocol {
+    var mapStyle: MapStyle = .standard
+    var isNorthUp: Bool = true
+    var zoomIndex: Int = 5
+    var defaultZoomIndex: Int = 5
+    var defaultMapStyle: MapStyle = .standard
+    var defaultIsNorthUp: Bool = true
+    var addressFormat: AddressFormat = .standard
+}

--- a/JustAMapTests/SettingsViewModelTests.swift
+++ b/JustAMapTests/SettingsViewModelTests.swift
@@ -63,6 +63,15 @@ final class SettingsViewModelTests: XCTestCase {
         sut.defaultZoomIndex = 11
         XCTAssertEqual(sut.zoomLevelDisplayText, "1,000km")
     }
+    
+    func testZoomLevelDisplayTextWithOutOfRangeIndex() {
+        // 範囲外の値でもデフォルト値が返される
+        sut.defaultZoomIndex = -1
+        XCTAssertEqual(sut.zoomLevelDisplayText, "10km") // デフォルト
+        
+        sut.defaultZoomIndex = 12
+        XCTAssertEqual(sut.zoomLevelDisplayText, "10km") // デフォルト
+    }
 }
 
 class MockMapSettingsStorage: MapSettingsStorageProtocol {

--- a/JustAMapTests/SettingsViewModelTests.swift
+++ b/JustAMapTests/SettingsViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import MapKit
 @testable import JustAMap
 
 final class SettingsViewModelTests: XCTestCase {
@@ -72,4 +73,36 @@ class MockMapSettingsStorage: MapSettingsStorageProtocol {
     var defaultMapStyle: MapStyle = .standard
     var defaultIsNorthUp: Bool = true
     var addressFormat: AddressFormat = .standard
+    
+    func saveMapStyle(_ style: MapStyle) {
+        mapStyle = style
+    }
+    
+    func loadMapStyle() -> MapStyle {
+        return mapStyle
+    }
+    
+    func saveMapOrientation(isNorthUp: Bool) {
+        self.isNorthUp = isNorthUp
+    }
+    
+    func loadMapOrientation() -> Bool {
+        return isNorthUp
+    }
+    
+    func saveZoomLevel(span: MKCoordinateSpan) {
+        // Not needed for these tests
+    }
+    
+    func loadZoomLevel() -> MKCoordinateSpan? {
+        return nil
+    }
+    
+    func saveZoomIndex(_ index: Int) {
+        zoomIndex = index
+    }
+    
+    func loadZoomIndex() -> Int? {
+        return zoomIndex
+    }
 }

--- a/JustAMapTests/SettingsViewModelTests.swift
+++ b/JustAMapTests/SettingsViewModelTests.swift
@@ -73,6 +73,7 @@ class MockMapSettingsStorage: MapSettingsStorageProtocol {
     var defaultMapStyle: MapStyle = .standard
     var defaultIsNorthUp: Bool = true
     var addressFormat: AddressFormat = .standard
+    var mockIsFirstLaunch: Bool = false
     
     func saveMapStyle(_ style: MapStyle) {
         mapStyle = style
@@ -104,5 +105,9 @@ class MockMapSettingsStorage: MapSettingsStorageProtocol {
     
     func loadZoomIndex() -> Int? {
         return zoomIndex
+    }
+    
+    func isFirstLaunch() -> Bool {
+        return mockIsFirstLaunch
     }
 }


### PR DESCRIPTION
## Summary
- Implemented settings screen functionality (Issue #3)
- Added configurable default values for zoom level, map style, and orientation
- Introduced address format options (standard, detailed, simple)

## Implementation Details

### Settings Screen
- Created `SettingsView` with intuitive UI for configuration
- Added `SettingsViewModel` to manage settings logic
- Navigation from main map view via settings button

### Default Settings
- **Default Zoom Level**: Configurable initial zoom (200m to 1,000km)
- **Default Map Style**: Choose between standard, hybrid, or satellite
- **Default Orientation**: North Up or Heading Up preference

### Address Format Options
1. **Standard**: Shows place name or locality
2. **Detailed**: Displays full address with additional info
3. **Simple**: Shows only city/ward name

### Persistence
- Extended `MapSettingsStorage` to handle new settings
- Settings are saved to UserDefaults
- App uses default settings on first launch
- User's current settings override defaults after first use

## Test Coverage
- Comprehensive unit tests for SettingsViewModel
- Updated MapSettingsStorage tests for new properties
- All existing tests pass with new Address model structure

## Changes Made
- 7 commits following TDD principles
- 580+ lines of code added/modified
- No breaking changes to existing functionality

## Test Plan
- [x] Settings screen opens from map view
- [x] All settings can be modified and saved
- [x] Settings persist across app restarts
- [x] Address format changes apply immediately
- [x] Default values work on fresh install
- [x] All unit tests pass