### PR TITLE
Fix failing tests in MapViewModelTests

### DIFF
--- a/JustAMapTests/MockLocationManager.swift
+++ b/JustAMapTests/MockLocationManager.swift
@@ -10,6 +10,9 @@ class MockLocationManager: LocationManagerProtocol {
     private(set) var didRequestAuthorization = false
     private(set) var isUpdatingLocation = false
     
+    /// テスト用: 現在位置を設定できるプロパティ
+    var currentLocation: CLLocation?
+    
     func requestLocationPermission() {
         didRequestAuthorization = true
     }


### PR DESCRIPTION
## Summary
- Add `currentLocation` property to `MockLocationManager` to fix failing tests
- Tests were failing because `MapViewModelTests` was trying to set `currentLocation` on the mock object

## Test plan
- [x] Run all tests with `xcodebuild test -scheme JustAMapTests`
- [x] Verify all tests pass
- [x] Confirm no other changes were made to the test suite