### PR TITLE
Fix test failure in MapRotationAnimationTests

### DIFF
--- a/JustAMap/Models/CompassViewModel.swift
+++ b/JustAMap/Models/CompassViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @MainActor
 class CompassViewModel: ObservableObject {
     @Published var rotation: Double = 0
-    @Published var isNorthUp: Bool = true  // MapControlsViewModelと同じ初期値
+    @Published var isNorthUp: Bool = true  // デフォルトはNorth Up（MapSettingsStorageと同じ）
     
     /// Closure called when the compass orientation is toggled
     /// - Parameter isNorthUp: The new orientation state (true for North Up, false for Heading Up)

--- a/JustAMapTests/MapRotationAnimationTests.swift
+++ b/JustAMapTests/MapRotationAnimationTests.swift
@@ -11,18 +11,24 @@ class MapRotationAnimationTests: XCTestCase {
     private var mapControlsViewModel: MapControlsViewModel!
     private var mapViewModel: MapViewModel!
     private var mockLocationManager: MockLocationManager!
+    private var mockSettingsStorage: MockMapSettingsStorage!
     
     override func setUp() {
         super.setUp()
         mockLocationManager = MockLocationManager()
         mapControlsViewModel = MapControlsViewModel()
-        mapViewModel = MapViewModel(locationManager: mockLocationManager, mapControlsViewModel: mapControlsViewModel)
+        mockSettingsStorage = MockMapSettingsStorage()
+        // テストケースでは初回起動を想定し、デフォルト値を使用
+        mockSettingsStorage.isFirstLaunchReturnValue = true
+        mockSettingsStorage.defaultIsNorthUp = true
+        mapViewModel = MapViewModel(locationManager: mockLocationManager, mapControlsViewModel: mapControlsViewModel, settingsStorage: mockSettingsStorage)
     }
     
     override func tearDown() {
         mapControlsViewModel = nil
         mapViewModel = nil
         mockLocationManager = nil
+        mockSettingsStorage = nil
         super.tearDown()
     }
     

--- a/JustAMapTests/TestDoubles/MockMapSettingsStorage.swift
+++ b/JustAMapTests/TestDoubles/MockMapSettingsStorage.swift
@@ -12,8 +12,12 @@ class MockMapSettingsStorage: MapSettingsStorageProtocol {
     var addressFormat: AddressFormat = .standard
     
     private var firstLaunch = true
+    var isFirstLaunchReturnValue: Bool?
     
     func isFirstLaunch() -> Bool {
+        if let returnValue = isFirstLaunchReturnValue {
+            return returnValue
+        }
         let isFirst = firstLaunch
         firstLaunch = false
         return isFirst


### PR DESCRIPTION
## Summary
- Fixed test failure in `MapRotationAnimationTests.testToggleMapOrientationChangesIsNorthUp`
- Updated test setup to ensure consistent initial state across view models
- Added `isFirstLaunchReturnValue` property to `MockMapSettingsStorage` for better test control

## Test plan
- [x] Run `xcodebuild test` to verify all tests pass
- [x] Specifically confirmed `testToggleMapOrientationChangesIsNorthUp` now passes
- [x] Verify no regression in compass functionality in the app