### PR TITLE
Fix AddressFormatterTests failures

### DIFF
--- a/JustAMapTests/AddressFormatterTests.swift
+++ b/JustAMapTests/AddressFormatterTests.swift
@@ -3,14 +3,18 @@ import XCTest
 
 final class AddressFormatterTests: XCTestCase {
     var sut: AddressFormatter!
+    var mockSettingsStorage: MockMapSettingsStorage!
     
     override func setUp() {
         super.setUp()
-        sut = AddressFormatter()
+        mockSettingsStorage = MockMapSettingsStorage()
+        mockSettingsStorage.addressFormat = .standard // テストはstandardフォーマットを期待
+        sut = AddressFormatter(settingsStorage: mockSettingsStorage)
     }
     
     override func tearDown() {
         sut = nil
+        mockSettingsStorage = nil
         super.tearDown()
     }
     


### PR DESCRIPTION
## Summary
- Fixed failing AddressFormatterTests by explicitly setting the address format
- Tests were failing because they expected standard format but the formatter was using settings from UserDefaults

## Changes
- Updated AddressFormatterTests to use MockMapSettingsStorage
- Explicitly set addressFormat to .standard in test setUp
- All tests now pass successfully

## Test plan
- [x] Run all tests with `xcodebuild test -scheme JustAMapTests -destination 'platform=iOS Simulator,name=iPhone 16'`
- [x] Verify all tests pass
- [x] Confirm no other tests were broken by this change