### PR TITLE
住所の標準表示フォーマットを変更

### DIFF
--- a/JustAMap/Models/AddressFormatter.swift
+++ b/JustAMap/Models/AddressFormatter.swift
@@ -57,13 +57,27 @@ class AddressFormatter {
     }
     
     private func determinePrimaryText(from address: Address) -> String {
-        // 優先順位: 1. 場所の名前, 2. 市区町村, 3. デフォルト
+        // 優先順位: 1. 場所の名前, 2. 都道府県+市区町村/郡など, 3. デフォルト
         if let name = address.name, !name.isEmpty {
             return name
         }
         
-        if let locality = address.locality, !locality.isEmpty {
-            return locality
+        var components: [String] = []
+        
+        // 都道府県を追加
+        if let administrativeArea = address.administrativeArea, !administrativeArea.isEmpty {
+            components.append(administrativeArea)
+        }
+        
+        // 市区町村/郡を追加（subAdministrativeAreaがあればそれを、なければlocalityを使用）
+        if let subAdministrativeArea = address.subAdministrativeArea, !subAdministrativeArea.isEmpty {
+            components.append(subAdministrativeArea)
+        } else if let locality = address.locality, !locality.isEmpty {
+            components.append(locality)
+        }
+        
+        if !components.isEmpty {
+            return components.joined(separator: " ")
         }
         
         return "現在地"

--- a/JustAMap/Models/AddressFormatter.swift
+++ b/JustAMap/Models/AddressFormatter.swift
@@ -22,7 +22,7 @@ class AddressFormatter {
         switch format {
         case .standard:
             let primaryText = determinePrimaryText(from: address)
-            let secondaryText = address.fullAddress
+            let secondaryText = buildFullAddressFromComponents(from: address)
             let formattedPostalCode = formatPostalCode(address.postalCode)
             
             return FormattedAddress(
@@ -33,7 +33,7 @@ class AddressFormatter {
             
         case .detailed:
             // 詳細フォーマット：常に完全な住所を表示
-            let primaryText = address.fullAddress
+            let primaryText = buildFullAddressFromComponents(from: address)
             let secondaryText = buildDetailedSecondaryText(from: address)
             let formattedPostalCode = formatPostalCode(address.postalCode)
             
@@ -125,5 +125,47 @@ class AddressFormatter {
         }
         
         return components.joined(separator: " / ")
+    }
+    
+    private func buildFullAddressFromComponents(from address: Address) -> String {
+        var components: [String] = []
+        
+        // 都道府県
+        if let administrativeArea = address.administrativeArea, !administrativeArea.isEmpty {
+            components.append(administrativeArea)
+        }
+        
+        // 市区町村/郡
+        if let subAdministrativeArea = address.subAdministrativeArea, !subAdministrativeArea.isEmpty {
+            components.append(subAdministrativeArea)
+        }
+        
+        // 区市町村
+        if let locality = address.locality, !locality.isEmpty {
+            components.append(locality)
+        }
+        
+        // fullAddressから上記のコンポーネントを除外した残りの部分を取得
+        if let fullAddress = address.fullAddress, !fullAddress.isEmpty {
+            var remainingAddress = fullAddress
+            
+            // 既に追加したコンポーネントを削除
+            for component in components {
+                remainingAddress = remainingAddress.replacingOccurrences(of: component, with: "")
+            }
+            
+            // 残りの住所部分（番地など）をトリムして追加
+            let trimmed = remainingAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                components.append(trimmed)
+            }
+        }
+        
+        // コンポーネントが空の場合はfullAddressをそのまま返す
+        if components.isEmpty {
+            return address.fullAddress
+        }
+        
+        return components.joined(separator: "")
     }
 }

--- a/JustAMap/Models/AddressFormatter.swift
+++ b/JustAMap/Models/AddressFormatter.swift
@@ -163,7 +163,7 @@ class AddressFormatter {
         
         // コンポーネントが空の場合はfullAddressをそのまま返す
         if components.isEmpty {
-            return address.fullAddress
+            return address.fullAddress ?? ""
         }
         
         return components.joined(separator: "")

--- a/JustAMap/Services/GeocodeService.swift
+++ b/JustAMap/Services/GeocodeService.swift
@@ -22,7 +22,7 @@ enum GeocodeError: Error, Equatable {
 /// 住所情報を表す構造体
 struct Address: Equatable {
     let name: String?
-    let fullAddress: String
+    let fullAddress: String?
     let postalCode: String?
     let locality: String?         // 市区町村
     let subAdministrativeArea: String? // 郡・地区

--- a/JustAMap/Services/GeocodeService.swift
+++ b/JustAMap/Services/GeocodeService.swift
@@ -82,9 +82,12 @@ class GeocodeService: GeocodeServiceProtocol {
     private func buildFullAddress(from placemark: CLPlacemark) -> String {
         var components: [String] = []
         
-        // 日本の住所フォーマット: 都道府県 > 市区町村 > 番地
+        // 日本の住所フォーマット: 都道府県 > 郡・市 > 区市町村 > 番地
         if let administrativeArea = placemark.administrativeArea {
             components.append(administrativeArea)
+        }
+        if let subAdministrativeArea = placemark.subAdministrativeArea {
+            components.append(subAdministrativeArea)
         }
         if let locality = placemark.locality {
             components.append(locality)

--- a/JustAMapTests/AddressFormatterTests.swift
+++ b/JustAMapTests/AddressFormatterTests.swift
@@ -55,7 +55,7 @@ final class AddressFormatterTests: XCTestCase {
         let formatted = sut.formatForDisplay(address)
         
         // Then
-        XCTAssertEqual(formatted.primaryText, "千代田区")
+        XCTAssertEqual(formatted.primaryText, "東京都 千代田区")
         XCTAssertEqual(formatted.secondaryText, "東京都千代田区丸の内1-9-1")
     }
     
@@ -97,5 +97,65 @@ final class AddressFormatterTests: XCTestCase {
         XCTAssertEqual(formatted.primaryText, "現在地")
         XCTAssertEqual(formatted.secondaryText, "不明な場所")
         XCTAssertNil(formatted.postalCode)
+    }
+    
+    func testStandardFormatWithoutNameShowsAdministrativeAreaAndSubAdministrativeArea() {
+        // Given
+        let address = Address(
+            name: nil,
+            fullAddress: "神奈川県横浜市西区みなとみらい2-3-1",
+            postalCode: "220-0012",
+            locality: "西区",
+            subAdministrativeArea: "横浜市",
+            administrativeArea: "神奈川県",
+            country: "日本"
+        )
+        
+        // When
+        let formatted = sut.formatForDisplay(address)
+        
+        // Then
+        XCTAssertEqual(formatted.primaryText, "神奈川県 横浜市")
+        XCTAssertEqual(formatted.secondaryText, "神奈川県横浜市西区みなとみらい2-3-1")
+    }
+    
+    func testStandardFormatWithoutNameAndSubAdministrativeAreaShowsAdministrativeAreaAndLocality() {
+        // Given
+        let address = Address(
+            name: nil,
+            fullAddress: "東京都千代田区丸の内1-9-1",
+            postalCode: "100-0005",
+            locality: "千代田区",
+            subAdministrativeArea: nil,
+            administrativeArea: "東京都",
+            country: "日本"
+        )
+        
+        // When
+        let formatted = sut.formatForDisplay(address)
+        
+        // Then
+        XCTAssertEqual(formatted.primaryText, "東京都 千代田区")
+        XCTAssertEqual(formatted.secondaryText, "東京都千代田区丸の内1-9-1")
+    }
+    
+    func testStandardFormatWithNameShowsName() {
+        // Given
+        let address = Address(
+            name: "横浜ランドマークタワー",
+            fullAddress: "神奈川県横浜市西区みなとみらい2-2-1",
+            postalCode: "220-8138",
+            locality: "西区",
+            subAdministrativeArea: "横浜市",
+            administrativeArea: "神奈川県",
+            country: "日本"
+        )
+        
+        // When
+        let formatted = sut.formatForDisplay(address)
+        
+        // Then
+        XCTAssertEqual(formatted.primaryText, "横浜ランドマークタワー")
+        XCTAssertEqual(formatted.secondaryText, "神奈川県横浜市西区みなとみらい2-2-1")
     }
 }


### PR DESCRIPTION
## Summary
- 住所の標準表示フォーマットを施設名でない場合、市区町村から「都道府県 + 市区町村/郡」に変更
- fullAddressの構築時にsubAdministrativeAreaを含めるように修正
- Address構造体のfullAddressをオプショナルに変更し、欠落する可能性に対応

## Changes
1. **AddressFormatter**の標準フォーマット実装を更新
   - 施設名がない場合は`administrativeArea + subAdministrativeArea/locality`を表示
   - fullAddressの代わりにコンポーネントから住所を構築する`buildFullAddressFromComponents`メソッドを追加

2. **GeocodeService**の改善
   - `buildFullAddress`メソッドにsubAdministrativeAreaを追加
   - Address構造体のfullAddressをString?に変更

3. **テストの更新**
   - 新しいフォーマットに対応したテストケースを追加
   - 既存のテストを新仕様に合わせて修正

## Test plan
- [ ] AddressFormatterTestsが全て成功すること
- [ ] 施設名がある場合は施設名が表示されること
- [ ] 施設名がない場合は「都道府県 市区町村」または「都道府県 郡」が表示されること
- [ ] アプリ起動時に住所が正しく表示されること