### PR TITLE
Add build artifact verification to iOS workflow

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -25,3 +25,19 @@ jobs:
         run: |
           export SDKROOT=$(xcrun --sdk iphonesimulator --show-sdk-path)
           make build
+
+      - name: Verify build artifacts
+        run: |
+          echo "Checking build artifacts..."
+          if [ -d "xtool/JustAMap.app" ]; then
+            echo "✓ App bundle found at xtool/JustAMap.app"
+            echo "App bundle contents:"
+            ls -la xtool/JustAMap.app/
+            echo "App executable size:"
+            ls -lh xtool/JustAMap.app/JustAMap
+          else
+            echo "✗ App bundle not found at expected location"
+            echo "Contents of xtool directory:"
+            ls -la xtool/ || echo "xtool directory not found"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- iOS build ワークフローにビルド成果物の確認ステップを追加
- `make build`の実行後、実際にアプリバンドルが生成されたことを確認

## Changes
- `.github/workflows/ios-build.yml`に「Verify build artifacts」ステップを追加
  - `xtool/JustAMap.app`の存在を確認
  - 存在する場合：アプリバンドルの内容と実行ファイルサイズを表示
  - 存在しない場合：エラーメッセージを表示してビルドを失敗させる

## Test plan
- [x] GitHub Actionsでビルドが成功することを確認
- [x] ビルド成果物の詳細情報がログに出力されることを確認