### PR TITLE
Add test execution to iOS build workflow

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Select Xcode 16.4
         run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
+      - name: Run tests
+        run: |
+          export SDKROOT=$(xcrun --sdk iphonesimulator --show-sdk-path)
+          make test
+
       - name: Build app
         run: |
           export SDKROOT=$(xcrun --sdk iphonesimulator --show-sdk-path)


### PR DESCRIPTION
## Summary
- Add `make test` step before building in iOS workflow
- Tests run with proper SDKROOT environment variable set
- Helps catch test failures earlier in the CI pipeline

## Test plan
- [ ] CI workflow should run tests before building
- [ ] Tests should execute with iOS simulator SDK
- [ ] Build should only proceed if tests pass