### PR TITLE
fix: correct Address parameter order in test

### DIFF
--- a/Tests/JustAMapTests/LocalizationTests.swift
+++ b/Tests/JustAMapTests/LocalizationTests.swift
@@ -59,11 +59,11 @@ final class LocalizationTests: XCTestCase {
         let address = Address(
             name: nil,
             fullAddress: nil,
+            postalCode: nil,
             locality: nil,
             subAdministrativeArea: nil,
             administrativeArea: nil,
-            country: nil,
-            postalCode: nil
+            country: nil
         )
         
         let formatted = formatter.formatForDisplay(address)


### PR DESCRIPTION
Fixes failing test in LocalizationTests.swift by correcting parameter order in Address initializer.

- Move postalCode before locality to match struct definition
- Resolves compilation error: "argument 'postalCode' must precede argument 'locality'"

References # 40

🤖 Generated with [Claude Code](https://claude.ai/code)