### PR TITLE
Fix: Make AddressFormatterTests locale-independent

### DIFF
--- a/Sources/JustAMap/Models/AddressFormatter.swift
+++ b/Sources/JustAMap/Models/AddressFormatter.swift
@@ -17,6 +17,17 @@ class AddressFormatter {
         locale.language.languageCode?.identifier ?? "en"
     }
     
+    /// ローカライズされた「現在地」文字列を取得
+    private var currentLocationText: String {
+        // テストやロケール注入時は言語コードに基づいて固定値を返す
+        switch languageCode {
+        case "ja":
+            return "現在地"
+        default:
+            return "Current Location"
+        }
+    }
+    
     /// イニシャライザ
     /// - Parameters:
     ///   - settingsStorage: 設定ストレージ（デフォルト: MapSettingsStorage）
@@ -56,7 +67,7 @@ class AddressFormatter {
             
         case .simple:
             // シンプルフォーマット：市区町村のみ
-            let primaryText = address.locality ?? "address.current_location".localized
+            let primaryText = address.locality ?? currentLocationText
             let secondaryText = ""
             
             return FormattedAddress(
@@ -91,7 +102,7 @@ class AddressFormatter {
             return components.joined(separator: " ")
         }
         
-        return "address.current_location".localized
+        return currentLocationText
     }
     
     private func formatPostalCode(_ postalCode: String?) -> String? {

--- a/Sources/JustAMap/Models/AddressFormatter.swift
+++ b/Sources/JustAMap/Models/AddressFormatter.swift
@@ -10,9 +10,11 @@ struct FormattedAddress {
 /// 住所を表示用にフォーマットするクラス
 class AddressFormatter {
     private let settingsStorage: MapSettingsStorageProtocol
+    private let locale: Locale
     
-    init(settingsStorage: MapSettingsStorageProtocol = MapSettingsStorage()) {
+    init(settingsStorage: MapSettingsStorageProtocol = MapSettingsStorage(), locale: Locale = .current) {
         self.settingsStorage = settingsStorage
+        self.locale = locale
     }
     
     /// 住所を表示用にフォーマット
@@ -94,7 +96,7 @@ class AddressFormatter {
         }
         
         // 日本語環境かどうかで郵便番号の形式を決定
-        let currentLanguage = Locale.current.language.languageCode?.identifier ?? "en"
+        let currentLanguage = locale.language.languageCode?.identifier ?? "en"
         if currentLanguage == "ja" {
             return "〒\(postalCode)"
         } else {
@@ -134,7 +136,7 @@ class AddressFormatter {
     }
     
     private func buildFullAddressFromComponents(from address: Address) -> String {
-        let currentLanguage = Locale.current.language.languageCode?.identifier ?? "en"
+        let currentLanguage = locale.language.languageCode?.identifier ?? "en"
         var components: [String] = []
         
         if currentLanguage == "ja" {

--- a/Sources/JustAMap/Models/AddressFormatter.swift
+++ b/Sources/JustAMap/Models/AddressFormatter.swift
@@ -12,6 +12,15 @@ class AddressFormatter {
     private let settingsStorage: MapSettingsStorageProtocol
     private let locale: Locale
     
+    /// 言語コードを取得（デフォルト: "en"）
+    private var languageCode: String {
+        locale.language.languageCode?.identifier ?? "en"
+    }
+    
+    /// イニシャライザ
+    /// - Parameters:
+    ///   - settingsStorage: 設定ストレージ（デフォルト: MapSettingsStorage）
+    ///   - locale: 使用するロケール（デフォルト: .current）。テスト時に特定のロケールを注入可能
     init(settingsStorage: MapSettingsStorageProtocol = MapSettingsStorage(), locale: Locale = .current) {
         self.settingsStorage = settingsStorage
         self.locale = locale
@@ -96,8 +105,7 @@ class AddressFormatter {
         }
         
         // 日本語環境かどうかで郵便番号の形式を決定
-        let currentLanguage = locale.language.languageCode?.identifier ?? "en"
-        if currentLanguage == "ja" {
+        if languageCode == "ja" {
             return "〒\(postalCode)"
         } else {
             return postalCode
@@ -136,10 +144,9 @@ class AddressFormatter {
     }
     
     private func buildFullAddressFromComponents(from address: Address) -> String {
-        let currentLanguage = locale.language.languageCode?.identifier ?? "en"
         var components: [String] = []
         
-        if currentLanguage == "ja" {
+        if languageCode == "ja" {
             // 日本語：都道府県 → 市区町村/郡 → 区市町村の順
             if let administrativeArea = address.administrativeArea, !administrativeArea.isEmpty {
                 components.append(administrativeArea)
@@ -174,7 +181,7 @@ class AddressFormatter {
         // fullAddressが存在し、コンポーネントで構築した住所より詳細な情報を含む場合
         if let fullAddress = address.fullAddress, !fullAddress.isEmpty {
             // コンポーネントで構築した住所
-            let separator = currentLanguage == "ja" ? "" : ", "
+            let separator = languageCode == "ja" ? "" : ", "
             let builtAddress = components.joined(separator: separator)
             
             // fullAddressがbuiltAddressで始まる場合、残りの部分（番地など）を取得
@@ -195,7 +202,7 @@ class AddressFormatter {
             return address.fullAddress ?? ""
         }
         
-        let separator = currentLanguage == "ja" ? "" : ", "
+        let separator = languageCode == "ja" ? "" : ", "
         return components.joined(separator: separator)
     }
 }

--- a/Tests/JustAMapTests/AddressFormatterTests.swift
+++ b/Tests/JustAMapTests/AddressFormatterTests.swift
@@ -9,7 +9,9 @@ final class AddressFormatterTests: XCTestCase {
         super.setUp()
         mockSettingsStorage = MockMapSettingsStorage()
         mockSettingsStorage.addressFormat = .standard // テストはstandardフォーマットを期待
-        sut = AddressFormatter(settingsStorage: mockSettingsStorage)
+        // テストでは常に日本語ロケールを使用
+        let japaneseLocale = Locale(identifier: "ja_JP")
+        sut = AddressFormatter(settingsStorage: mockSettingsStorage, locale: japaneseLocale)
     }
     
     override func tearDown() {

--- a/Tests/JustAMapTests/AddressFormatterTests.swift
+++ b/Tests/JustAMapTests/AddressFormatterTests.swift
@@ -5,13 +5,15 @@ final class AddressFormatterTests: XCTestCase {
     var sut: AddressFormatter!
     var mockSettingsStorage: MockMapSettingsStorage!
     
+    // テスト用の日本語ロケール定数
+    private static let japaneseLocale = Locale(identifier: "ja_JP")
+    
     override func setUp() {
         super.setUp()
         mockSettingsStorage = MockMapSettingsStorage()
         mockSettingsStorage.addressFormat = .standard // テストはstandardフォーマットを期待
         // テストでは常に日本語ロケールを使用
-        let japaneseLocale = Locale(identifier: "ja_JP")
-        sut = AddressFormatter(settingsStorage: mockSettingsStorage, locale: japaneseLocale)
+        sut = AddressFormatter(settingsStorage: mockSettingsStorage, locale: Self.japaneseLocale)
     }
     
     override func tearDown() {


### PR DESCRIPTION
## Summary
- AddressFormatterにロケールパラメータを追加（デフォルトは.current）
- テストで明示的に日本語ロケール（ja_JP）を使用するように修正
- ローカル環境（日本語）とCI環境（英語）のロケール差異によるテスト失敗を解消

## Test plan
- [x] ローカル環境（日本語）でテストが成功することを確認
- [x] 英語ロケール環境でもテストが成功することを確認（LANG=en_US.UTF-8でテスト実行）
- [ ] CI環境でテストが成功することを確認