### PR TITLE
fix: resolve ForEach warning in CompassView

### DIFF
--- a/Sources/JustAMap/Views/CompassView.swift
+++ b/Sources/JustAMap/Views/CompassView.swift
@@ -11,7 +11,7 @@ struct CompassView: View {
         static let shadowRadius: CGFloat = 3
         static let tickLength: CGFloat = 2
         static let tickWidth: CGFloat = 1
-        static let tickCount: Int = 12  // 目盛りの数（30度ごと）
+        // tickCount は ForEach のwarning回避のため直接12を使用
     }
     
     var body: some View {
@@ -30,12 +30,12 @@ struct CompassView: View {
                     .frame(width: Constants.size, height: Constants.size)
                 
                 // Compass dial with ticks
-                ForEach(0..<Constants.tickCount) { index in
+                ForEach(0..<12) { index in
                     Rectangle()
                         .fill(Color(.systemGray))  // より濃い目盛り
                         .frame(width: Constants.tickWidth, height: index % 3 == 0 ? Constants.tickLength * 1.5 : Constants.tickLength)
                         .offset(y: -Constants.size / 2 + Constants.tickLength + 3)
-                        .rotationEffect(.degrees(Double(index) * (360.0 / Double(Constants.tickCount))))
+                        .rotationEffect(.degrees(Double(index) * 30.0))
                 }
                 
                 // Compass needle container with fixed frame

--- a/Tests/JustAMapTests/CompassViewTests.swift
+++ b/Tests/JustAMapTests/CompassViewTests.swift
@@ -56,6 +56,5 @@ final class CompassViewTests: XCTestCase {
         XCTAssertEqual(CompassView.Constants.shadowRadius, 3)
         XCTAssertEqual(CompassView.Constants.tickLength, 2)
         XCTAssertEqual(CompassView.Constants.tickWidth, 1)
-        XCTAssertEqual(CompassView.Constants.tickCount, 12)
     }
 }


### PR DESCRIPTION
## Summary
- ForEach(0..<Constants.tickCount) で発生していたwarningを修正
- SwiftUIのForEachは定数範囲を期待するため、直接12を使用するように変更
- テストファイルも同様に修正

## Changes
- `ForEach(0..<Constants.tickCount)` を `ForEach(0..<12)` に変更
- 回転計算を `Double(index) * 30.0` に直接変更
- `Constants.tickCount` の定義を削除し、コメントで説明を追加
- テストファイルから `tickCount` の参照を削除

## Test plan
- [x] `make clean && make build` でwarningが出ないことを確認
- [x] `make test` で全テストがパスすることを確認