### PR TITLE
feat: implement dynamic simulator selection for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,38 @@ APP_BUNDLE := xtool/JustAMap.app
 # Example: make install DEVICE_ID=00008140-000C7D8E362A801C
 DEVICE_ID ?= 
 
+# Dynamically select an available iOS simulator for testing
+# Priority: iPhone Pro models > iPhone models > Any iOS simulator
+SIMULATOR_NAME := $(shell \
+	simulator=$$(xcrun simctl list devices available 2>/dev/null | \
+		grep -E "iPhone.*Pro.*\(.*\)" | \
+		head -1 | \
+		sed 's/^[[:space:]]*//' | \
+		sed 's/[[:space:]]*(.*//' | \
+		sed 's/[[:space:]]*$$//'); \
+	if [ -z "$$simulator" ]; then \
+		simulator=$$(xcrun simctl list devices available 2>/dev/null | \
+			grep -E "iPhone.*\(.*\)" | \
+			head -1 | \
+			sed 's/^[[:space:]]*//' | \
+			sed 's/[[:space:]]*(.*//' | \
+			sed 's/[[:space:]]*$$//'); \
+	fi; \
+	if [ -z "$$simulator" ]; then \
+		simulator=$$(xcrun simctl list devices available 2>/dev/null | \
+			grep -E "iOS.*\(.*\)" | \
+			head -1 | \
+			sed 's/^[[:space:]]*//' | \
+			sed 's/[[:space:]]*(.*//' | \
+			sed 's/[[:space:]]*$$//'); \
+	fi; \
+	if [ -z "$$simulator" ]; then \
+		echo "iPhone 16"; \
+	else \
+		echo "$$simulator"; \
+	fi \
+)
+
 # Build the app with xtool
 build:
 	@echo "Building app with xtool..."
@@ -27,11 +59,12 @@ build:
 # Test the app
 test:
 	@echo "Running tests..."
+	@echo "Selected simulator: $(SIMULATOR_NAME)"
 	@if command -v xcodebuild >/dev/null 2>&1; then \
 		if command -v xcpretty >/dev/null 2>&1; then \
-			set -o pipefail && xcodebuild test -scheme JustAMap -destination 'platform=iOS Simulator,name=iPhone 16' | xcpretty --test; \
+			set -o pipefail && xcodebuild test -scheme JustAMap -destination 'platform=iOS Simulator,name=$(SIMULATOR_NAME)' | xcpretty --test; \
 		else \
-			xcodebuild test -scheme JustAMap -destination 'platform=iOS Simulator,name=iPhone 16'; \
+			xcodebuild test -scheme JustAMap -destination 'platform=iOS Simulator,name=$(SIMULATOR_NAME)'; \
 		fi \
 	else \
 		echo "Error: xcodebuild not found. Tests can only be run on macOS with Xcode installed."; \
@@ -115,6 +148,13 @@ devices:
 	@echo "Available devices:"
 	@xtool devices
 
+# Show selected simulator for testing
+show-simulator:
+	@echo "Selected simulator for testing: $(SIMULATOR_NAME)"
+	@echo ""
+	@echo "Available iOS simulators:"
+	@xcrun simctl list devices available | grep -E "(iPhone|iOS)" | head -10
+
 # Lint Swift code
 lint:
 	@if command -v swiftlint >/dev/null 2>&1; then \
@@ -148,6 +188,7 @@ help:
 	@echo "  make compile-assets - Compile assets (macOS only)"
 	@echo "  make fix-assets    - Fix assets in app bundle"
 	@echo "  make devices       - List available devices"
+	@echo "  make show-simulator - Show selected simulator for testing"
 	@echo "  make lint          - Run SwiftLint"
 	@echo "  make format        - Format Swift code"
 	@echo "  make help          - Show this help"

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ SIMULATOR_NAME := $(shell \
 		echo "iPhone 16"; \
 	else \
 		echo "$$simulator"; \
-	fi \
+	fi
 )
 
 # Build the app with xtool

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ APP_BUNDLE := xtool/JustAMap.app
 # Example: make install DEVICE_ID=00008140-000C7D8E362A801C
 DEVICE_ID ?= 
 
+# Host architecture for simulator selection
+HOST_ARCH := $(shell uname -m)
+
 # Dynamically select an available iOS simulator for testing
 # This is done via a helper script to avoid complex Makefile escaping.
 SIMULATOR_ID := $(shell ./scripts/find-simulator.sh)
@@ -31,12 +34,12 @@ build:
 # Test the app
 test:
 	@echo "Running tests..."
-	@echo "Selected simulator ID: $(SIMULATOR_ID)"
+	@echo "Selected simulator ID: $(SIMULATOR_ID) (arch: $(HOST_ARCH))"
 	@if command -v xcodebuild >/dev/null 2>&1; then \
 		if command -v xcpretty >/dev/null 2>&1; then \
-			set -o pipefail && xcodebuild test -scheme JustAMap -destination 'platform=iOS Simulator,id=$(SIMULATOR_ID)' | xcpretty --test; \
+			set -o pipefail && xcodebuild test -scheme JustAMap -destination 'platform=iOS Simulator,id=$(SIMULATOR_ID),arch=$(HOST_ARCH)' | xcpretty --test; \
 		else \
-			xcodebuild test -scheme JustAMap -destination 'platform=iOS Simulator,id=$(SIMULATOR_ID)'; \
+			xcodebuild test -scheme JustAMap -destination 'platform=iOS Simulator,id=$(SIMULATOR_ID),arch=$(HOST_ARCH)'; \
 		fi \
 	else \
 		echo "Error: xcodebuild not found. Tests can only be run on macOS with Xcode installed."; \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ SIMULATOR_NAME := $(shell \
 		echo "iPhone 16"; \
 	else \
 		echo "$$simulator"; \
-	fi
+	fi \
 )
 
 # Build the app with xtool

--- a/scripts/find-simulator.sh
+++ b/scripts/find-simulator.sh
@@ -1,29 +1,45 @@
 #!/bin/bash
 #
-# Finds the UDID of an available iOS simulator.
-# Priority: iPhone Pro models > iPhone models > Any available iPhone
+# Finds the UDID of the most appropriate available iOS simulator.
+# It prioritizes simulators matching the host architecture (arm64 vs x86_64)
+# and prefers Pro models over regular ones.
 
 set -euo pipefail
 
-# Find best available simulator UDID
-pro_simulator_udid=$(xcrun simctl list devices available | grep 'iPhone' | grep 'Pro' | grep -o '[A-F0-9-]\{36\}' | head -n 1 || true)
+# Determine host architecture
+HOST_ARCH=$(uname -m)
 
-if [ -n "$pro_simulator_udid" ]; then
-    echo "$pro_simulator_udid"
+# Get all available iOS Simulator destinations from xcodebuild
+# The output format is like: { platform:iOS Simulator, arch:arm64, id:UDID, OS:17.0.1, name:iPhone 15 Pro }
+DESTINATIONS=$(xcodebuild -showdestinations -scheme JustAMap 2>/dev/null | grep "platform:iOS Simulator")
+
+# --- Find the best possible UDID --- 
+
+# 1. iPhone Pro matching host architecture
+UDID=$(echo "$DESTINATIONS" | grep "name:iPhone" | grep "Pro" | grep "arch:$HOST_ARCH" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
+if [ -n "$UDID" ]; then
+    echo "$UDID"
     exit 0
 fi
 
-first_simulator_udid=$(xcrun simctl list devices available | grep 'iPhone' | grep -o '[A-F0-9-]\{36\}' | head -n 1 || true)
-
-if [ -n "$first_simulator_udid" ]; then
-    echo "$first_simulator_udid"
+# 2. Any iPhone matching host architecture
+UDID=$(echo "$DESTINATIONS" | grep "name:iPhone" | grep "arch:$HOST_ARCH" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
+if [ -n "$UDID" ]; then
+    echo "$UDID"
     exit 0
 fi
 
-# Fallback if no simulator is found by printing the UDID of the latest iPhone 15 Pro
-fallback_udid=$(xcrun simctl list devices available | grep 'iPhone 15 Pro' | grep -o '[A-F0-9-]\{36\}' | head -n 1 || true)
-if [ -n "$fallback_udid" ]; then
-    echo "$fallback_udid"
+# 3. (Fallback) iPhone Pro with any architecture
+UDID=$(echo "$DESTINATIONS" | grep "name:iPhone" | grep "Pro" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
+if [ -n "$UDID" ]; then
+    echo "$UDID"
+    exit 0
+fi
+
+# 4. (Fallback) Any iPhone with any architecture
+UDID=$(echo "$DESTINATIONS" | grep "name:iPhone" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
+if [ -n "$UDID" ]; then
+    echo "$UDID"
     exit 0
 fi
 

--- a/scripts/find-simulator.sh
+++ b/scripts/find-simulator.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Finds the UDID of an available iOS simulator.
+# Priority: iPhone Pro models > iPhone models > Any available iPhone
+
+set -euo pipefail
+
+# Find best available simulator UDID
+pro_simulator_udid=$(xcrun simctl list devices available | grep 'iPhone' | grep 'Pro' | grep -o '[A-F0-9-]\{36\}' | head -n 1 || true)
+
+if [ -n "$pro_simulator_udid" ]; then
+    echo "$pro_simulator_udid"
+    exit 0
+fi
+
+first_simulator_udid=$(xcrun simctl list devices available | grep 'iPhone' | grep -o '[A-F0-9-]\{36\}' | head -n 1 || true)
+
+if [ -n "$first_simulator_udid" ]; then
+    echo "$first_simulator_udid"
+    exit 0
+fi
+
+# Fallback if no simulator is found by printing the UDID of the latest iPhone 15 Pro
+fallback_udid=$(xcrun simctl list devices available | grep 'iPhone 15 Pro' | grep -o '[A-F0-9-]\{36\}' | head -n 1 || true)
+if [ -n "$fallback_udid" ]; then
+    echo "$fallback_udid"
+    exit 0
+fi
+
+# If all else fails, exit with an error
+>&2 echo "Error: No suitable iOS Simulator found."
+exit 1


### PR DESCRIPTION
Implements dynamic simulator selection for testing to resolve hard-coded simulator dependency issue.

## Changes
- Add SIMULATOR_NAME variable with intelligent selection logic
- Priority order: iPhone Pro models > iPhone models > iOS simulators
- Fallback to "iPhone 16" if no simulators are available
- Add "make show-simulator" target for debugging
- Update test target to use dynamic simulator selection
- Add simulator selection display in test output

Resolves #45

Generated with [Claude Code](https://claude.ai/code)