### PR TITLE
Fix Claude Code Action permissions for workflow_run events

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Fixed OIDC token validation errors when Claude Code Action is triggered by workflow_run events
- Changed permissions from 'read' to 'write' for pull-requests and issues

## Problem
Claude Code Action was failing with "Invalid OIDC token" error when triggered by CI failures. This was happening because workflow_run events require write permissions for pull-requests and issues.

## Solution
Updated the permissions in `.github/workflows/claude.yml`:
- `pull-requests: read` → `pull-requests: write`
- `issues: read` → `issues: write`

## Test plan
- [x] Created this PR with the fix
- [ ] Wait for CI to pass
- [ ] If CI fails, Claude Code Action should now work properly

## Related
- Failed run: https://github.com/skoji/just-a-map/actions/runs/16185987714