### PR TITLE
Add github_token parameter to fix Claude Code Action authentication

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Added `github_token: ${{ secrets.GITHUB_TOKEN }}` parameter to Claude Code Action configuration

## Problem
Claude Code Action was still failing with OIDC token validation errors after the previous permission fix. The error message specifically suggested:
> If you instead wish to use this action with a custom GitHub token or custom GitHub app, provide a `github_token` in the `uses` section of the app in your workflow yml file.

## Solution
Added the `github_token` parameter as suggested by the error message. This should provide the necessary authentication for Claude Code Action when triggered by workflow_run events.

## Test plan
- [x] Created this PR with the fix
- [ ] Wait for CI to pass
- [ ] If CI fails again, Claude Code Action should now authenticate properly

## Related
- Previous PR: #61
- Failed run: https://github.com/skoji/just-a-map/actions/runs/16186104224