### PR TITLE
Add automatic @claude comment on CI failures in PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,9 +9,6 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
-  workflow_run:
-    workflows: ["iOS build and test (macOS)"]
-    types: [completed]
 
 jobs:
   claude:
@@ -19,13 +16,12 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch != 'main')
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -39,7 +35,6 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -58,15 +53,11 @@ jobs:
           allowed_tools: "Bash(git *),Bash(gh *),Bash(xcodebuild *),Bash(swift *),Bash(pwd),Bash(ls *),Bash(cat *),Bash(echo *)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
-          custom_instructions: |
-            When working on a PR and CI fails:
-            1. Automatically check the CI logs to understand the failure
-            2. If it's a test failure, analyze and fix the failing tests
-            3. If it's a build error, fix the compilation issues
-            4. After fixing, explain what was wrong and what you changed
-            Always run swift test locally before pushing fixes
+          # custom_instructions: |
+          #   Follow our coding standards
+          #   Ensure all new code has tests
+          #   Use TypeScript for new files
           
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -47,3 +47,31 @@ jobs:
             ls -la xtool/ || echo "xtool directory not found"
             exit 1
           fi
+
+      - name: Comment @claude on PR failure
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const workflowRun = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            
+            const comment = `@claude The CI has failed on this PR. Please check the [workflow run](${workflowRun}) and help fix the issues.
+            
+            <details>
+            <summary>Failed Workflow Details</summary>
+            
+            - **Workflow**: ${context.workflow}
+            - **Run ID**: ${context.runId}
+            - **Run Number**: ${context.runNumber}
+            - **Event**: ${context.eventName}
+            - **SHA**: ${context.sha}
+            
+            </details>`;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: comment
+            });

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: macos-15
+    permissions:
+      contents: read
+      pull-requests: write  # Required for commenting on PRs
     env:
       TOOLCHAINS: swift
       XT_SIGNING: off


### PR DESCRIPTION
## Summary
- Added automatic commenting functionality to the iOS build workflow
- When CI fails on a PR, it automatically posts a comment mentioning @claude
- This replaces the removed workflow_run trigger functionality

## Background
Due to OIDC authentication issues with workflow_run events (#61, #62), we removed the automatic Claude Code triggering on CI failures. This PR provides an alternative solution by automatically commenting @claude when CI fails.

## Implementation
Added a new step to `.github/workflows/ios-build.yml`:
- Only triggers when the workflow fails AND it's a pull request
- Uses `actions/github-script@v7` to post a comment
- Includes a direct link to the failed workflow run
- Provides workflow context in a collapsible details section

## Benefits
- No OIDC authentication issues (uses standard GITHUB_TOKEN)
- More transparent - users can see when Claude is being invoked
- Still achieves the goal of automatically getting Claude's help on CI failures
- Works reliably with existing permissions

## Test plan
- [x] Created this PR with the implementation
- [ ] CI should pass normally
- [ ] To test failure behavior: Create a test PR with intentionally broken code
- [ ] Verify that @claude comment is posted when CI fails on that PR