### PR TITLE
Replace @claude comment with label trigger for CI failures

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,7 +6,9 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened, assigned, labeled]
+  pull_request:
+    types: [labeled]
   pull_request_review:
     types: [submitted]
 
@@ -16,7 +18,9 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'claude')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -51,15 +51,25 @@ jobs:
             exit 1
           fi
 
-      - name: Comment @claude on PR failure
+      - name: Add claude label on PR failure
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const prNumber = context.issue.number;
+            
+            // Add the 'claude' label to trigger Claude Code Action
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['claude']
+            });
+            
+            // Also post a comment with workflow details
             const workflowRun = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             
-            const comment = `@claude The CI has failed on this PR. Please check the [workflow run](${workflowRun}) and help fix the issues.
+            const comment = `CI has failed on this PR. The 'claude' label has been added to trigger Claude Code Action.
             
             <details>
             <summary>Failed Workflow Details</summary>
@@ -69,6 +79,7 @@ jobs:
             - **Run Number**: ${context.runNumber}
             - **Event**: ${context.eventName}
             - **SHA**: ${context.sha}
+            - **[View workflow run](${workflowRun})**
             
             </details>`;
             


### PR DESCRIPTION
Changed the CI failure handling to use label-based triggering instead of @claude comments, since comments from github-actions bot don't trigger Claude Code Action.

Changes:
- Modified ios-build.yml to add 'claude' label on PR failures
- Updated claude.yml to respond to label events on PRs and issues
- Added conditions to trigger on 'labeled' action with 'claude' label

This ensures Claude Code Action is triggered when CI fails on PRs.