### PR TITLE
位置情報更新頻度の改善：速度ベースから高度ベースへ変更

### DIFF
--- a/Sources/JustAMap/Models/LocationManager.swift
+++ b/Sources/JustAMap/Models/LocationManager.swift
@@ -67,19 +67,18 @@ class LocationManager: NSObject, LocationManagerProtocol {
         // カメラの高度に基づいてdistanceFilterを計算
         // 高度が低いほど（ズームインしているほど）細かく更新（小さいdistanceFilter）
         
-        let newDistanceFilter: CLLocationDistance
-        if altitude <= 500 {
+        let newDistanceFilter = if altitude <= 500 {
             // 非常に詳細なズーム（街区レベル以下）
-            newDistanceFilter = 5.0
+            5.0
         } else if altitude <= 2000 {
             // 詳細なズーム（地区レベル以下）
-            newDistanceFilter = 10.0
+            10.0
         } else if altitude <= 10000 {
             // 標準的なズーム（市レベル以下）
-            newDistanceFilter = 20.0
+            20.0
         } else {
             // 広域ズーム（市レベルより広域）
-            newDistanceFilter = 50.0
+            50.0
         }
         
         // 変化が大きい場合のみ更新（頻繁な更新を避ける）

--- a/Sources/JustAMap/Models/LocationManager.swift
+++ b/Sources/JustAMap/Models/LocationManager.swift
@@ -63,19 +63,24 @@ class LocationManager: NSObject, LocationManagerProtocol {
         locationManager.stopUpdatingHeading()
     }
     
-    func adjustUpdateFrequency(forSpeed speed: Double, zoomDistance: Double) {
-        // 速度とズームレベルに基づいてdistanceFilterを計算
-        // 高速 + 近いズーム = 頻繁な更新（小さいdistanceFilter）
-        // 低速 + 遠いズーム = 少ない更新（大きいdistanceFilter）
+    func adjustUpdateFrequency(forAltitude altitude: Double) {
+        // カメラの高度に基づいてdistanceFilterを計算
+        // 高度が低いほど（ズームインしているほど）細かく更新（小さいdistanceFilter）
         
-        let speedFactor = min(max(speed / 60.0, 0.1), 1.0) // 0.1 ~ 1.0 に正規化
-        let zoomFactor = min(max(zoomDistance / 5000.0, 0.1), 1.0) // 0.1 ~ 1.0 に正規化
-        
-        // 逆相関：速度が速くズームが近いほど小さい値
-        let combinedFactor = 1.0 - (speedFactor * (1.0 - zoomFactor))
-        
-        // 5m ~ 50m の範囲で調整
-        let newDistanceFilter = 5.0 + (combinedFactor * 45.0)
+        let newDistanceFilter: CLLocationDistance
+        if altitude <= 500 {
+            // 非常に詳細なズーム（街区レベル以下）
+            newDistanceFilter = 5.0
+        } else if altitude <= 2000 {
+            // 詳細なズーム（地区レベル以下）
+            newDistanceFilter = 10.0
+        } else if altitude <= 10000 {
+            // 標準的なズーム（市レベル以下）
+            newDistanceFilter = 20.0
+        } else {
+            // 広域ズーム（市レベルより広域）
+            newDistanceFilter = 50.0
+        }
         
         // 変化が大きい場合のみ更新（頻繁な更新を避ける）
         if abs(locationManager.distanceFilter - newDistanceFilter) > 2.0 {

--- a/Sources/JustAMap/Models/LocationManagerProtocol.swift
+++ b/Sources/JustAMap/Models/LocationManagerProtocol.swift
@@ -19,11 +19,9 @@ protocol LocationManagerProtocol: AnyObject {
     /// 位置情報の更新を停止
     func stopLocationUpdates()
     
-    /// 速度とズームレベルに基づいて更新頻度を調整
-    /// - Parameters:
-    ///   - speed: 現在の速度（km/h）
-    ///   - zoomDistance: 地図のズーム距離（メートル）
-    func adjustUpdateFrequency(forSpeed speed: Double, zoomDistance: Double)
+    /// ズームレベルに基づいて更新頻度を調整
+    /// - Parameter zoomLevel: 地図のズームレベル
+    func adjustUpdateFrequency(forZoomLevel zoomLevel: Double)
 }
 
 /// LocationManagerのイベントを受け取るデリゲート

--- a/Sources/JustAMap/Models/LocationManagerProtocol.swift
+++ b/Sources/JustAMap/Models/LocationManagerProtocol.swift
@@ -19,9 +19,9 @@ protocol LocationManagerProtocol: AnyObject {
     /// 位置情報の更新を停止
     func stopLocationUpdates()
     
-    /// ズームレベルに基づいて更新頻度を調整
-    /// - Parameter zoomLevel: 地図のズームレベル
-    func adjustUpdateFrequency(forZoomLevel zoomLevel: Double)
+    /// カメラの高度に基づいて更新頻度を調整
+    /// - Parameter altitude: 地図カメラの高度（メートル）
+    func adjustUpdateFrequency(forAltitude altitude: Double)
 }
 
 /// LocationManagerのイベントを受け取るデリゲート

--- a/Sources/JustAMap/Models/MapViewModel.swift
+++ b/Sources/JustAMap/Models/MapViewModel.swift
@@ -299,12 +299,9 @@ extension MapViewModel: LocationManagerDelegate {
             // 住所を取得
             self.fetchAddress(for: location)
             
-            // 速度とズームレベルに基づいて更新頻度を調整
-            // 速度が無効な場合は、現在の速度値を使用（前回の有効な値）
-            let speedForAdjustment = location.speed >= 0 ? location.speed : (self.currentSpeed ?? 0)
-            let speed = max(0, speedForAdjustment * 3.6) // m/s to km/h, 負の値は0に
-            let zoomDistance = self.mapControlsViewModel.currentAltitude
-            manager.adjustUpdateFrequency(forSpeed: speed, zoomDistance: zoomDistance)
+            // カメラの高度に基づいて更新頻度を調整
+            let altitude = self.mapControlsViewModel.currentAltitude
+            manager.adjustUpdateFrequency(forAltitude: altitude)
         }
     }
     

--- a/Tests/JustAMapTests/LocationManagerTests.swift
+++ b/Tests/JustAMapTests/LocationManagerTests.swift
@@ -92,43 +92,52 @@ final class LocationManagerTests: XCTestCase {
         XCTAssertEqual(mockDelegate.lastAuthorizationStatus, .authorizedWhenInUse)
     }
     
-    func testLocationManagerAdjustsDistanceFilterForHighSpeedAndCloseZoom() {
+    func testLocationManagerAdjustsDistanceFilterForVeryDetailedZoom() {
         // Given
         sut = MockLocationManager()
-        let speed = 60.0 // km/h
-        let zoomDistance = 500.0 // meters (close zoom)
+        let zoomLevel = 17.0 // Very detailed zoom level
         
         // When
-        sut.adjustUpdateFrequency(forSpeed: speed, zoomDistance: zoomDistance)
+        sut.adjustUpdateFrequency(forZoomLevel: zoomLevel)
         
         // Then
-        XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 5.0) // 5m for high speed + close zoom
+        XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 5.0) // 5m for very detailed zoom
     }
     
-    func testLocationManagerAdjustsDistanceFilterForLowSpeedAndFarZoom() {
+    func testLocationManagerAdjustsDistanceFilterForWideAreaZoom() {
         // Given
         sut = MockLocationManager()
-        let speed = 10.0 // km/h
-        let zoomDistance = 5000.0 // meters (far zoom)
+        let zoomLevel = 10.0 // Wide area zoom level
         
         // When
-        sut.adjustUpdateFrequency(forSpeed: speed, zoomDistance: zoomDistance)
+        sut.adjustUpdateFrequency(forZoomLevel: zoomLevel)
         
         // Then
-        XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 50.0) // 50m for low speed + far zoom
+        XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 50.0) // 50m for wide area zoom
     }
     
-    func testLocationManagerAdjustsDistanceFilterForMediumSpeed() {
+    func testLocationManagerAdjustsDistanceFilterForDetailedZoom() {
         // Given
         sut = MockLocationManager()
-        let speed = 30.0 // km/h
-        let zoomDistance = 1000.0 // meters
+        let zoomLevel = 15.0 // Detailed zoom level
         
         // When
-        sut.adjustUpdateFrequency(forSpeed: speed, zoomDistance: zoomDistance)
+        sut.adjustUpdateFrequency(forZoomLevel: zoomLevel)
         
         // Then
-        XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 10.0) // 10m for medium conditions
+        XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 10.0) // 10m for detailed zoom
+    }
+    
+    func testLocationManagerAdjustsDistanceFilterForStandardZoom() {
+        // Given
+        sut = MockLocationManager()
+        let zoomLevel = 13.0 // Standard zoom level
+        
+        // When
+        sut.adjustUpdateFrequency(forZoomLevel: zoomLevel)
+        
+        // Then
+        XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 20.0) // 20m for standard zoom
     }
     
     func testLocationManagerReportsPauseToDelegate() {

--- a/Tests/JustAMapTests/LocationManagerTests.swift
+++ b/Tests/JustAMapTests/LocationManagerTests.swift
@@ -95,10 +95,10 @@ final class LocationManagerTests: XCTestCase {
     func testLocationManagerAdjustsDistanceFilterForVeryDetailedZoom() {
         // Given
         sut = MockLocationManager()
-        let zoomLevel = 17.0 // Very detailed zoom level
+        let altitude = 200.0 // Very low altitude (very detailed zoom)
         
         // When
-        sut.adjustUpdateFrequency(forZoomLevel: zoomLevel)
+        sut.adjustUpdateFrequency(forAltitude: altitude)
         
         // Then
         XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 5.0) // 5m for very detailed zoom
@@ -107,10 +107,10 @@ final class LocationManagerTests: XCTestCase {
     func testLocationManagerAdjustsDistanceFilterForWideAreaZoom() {
         // Given
         sut = MockLocationManager()
-        let zoomLevel = 10.0 // Wide area zoom level
+        let altitude = 50000.0 // High altitude (wide area zoom)
         
         // When
-        sut.adjustUpdateFrequency(forZoomLevel: zoomLevel)
+        sut.adjustUpdateFrequency(forAltitude: altitude)
         
         // Then
         XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 50.0) // 50m for wide area zoom
@@ -119,10 +119,10 @@ final class LocationManagerTests: XCTestCase {
     func testLocationManagerAdjustsDistanceFilterForDetailedZoom() {
         // Given
         sut = MockLocationManager()
-        let zoomLevel = 15.0 // Detailed zoom level
+        let altitude = 1000.0 // Low altitude (detailed zoom)
         
         // When
-        sut.adjustUpdateFrequency(forZoomLevel: zoomLevel)
+        sut.adjustUpdateFrequency(forAltitude: altitude)
         
         // Then
         XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 10.0) // 10m for detailed zoom
@@ -131,10 +131,10 @@ final class LocationManagerTests: XCTestCase {
     func testLocationManagerAdjustsDistanceFilterForStandardZoom() {
         // Given
         sut = MockLocationManager()
-        let zoomLevel = 13.0 // Standard zoom level
+        let altitude = 5000.0 // Medium altitude (standard zoom)
         
         // When
-        sut.adjustUpdateFrequency(forZoomLevel: zoomLevel)
+        sut.adjustUpdateFrequency(forAltitude: altitude)
         
         // Then
         XCTAssertEqual((sut as! MockLocationManager).distanceFilter, 20.0) // 20m for standard zoom

--- a/Tests/JustAMapTests/MockLocationManager.swift
+++ b/Tests/JustAMapTests/MockLocationManager.swift
@@ -11,29 +11,6 @@ class MockLocationManager: LocationManagerProtocol {
     private(set) var isUpdatingLocation = false
     private(set) var distanceFilter: Double = 10.0
     
-    // Speed thresholds (km/h)
-    private enum SpeedThreshold {
-        static let high: Double = 60.0
-        static let low: Double = 10.0
-        static let medium: Double = 30.0
-        static let tolerance: Double = 1.0  // Tolerance for medium speed comparison
-    }
-    
-    // Zoom distance thresholds (meters)
-    private enum ZoomThreshold {
-        static let close: Double = 500.0
-        static let far: Double = 5000.0
-        static let medium: Double = 1000.0
-        static let tolerance: Double = 50.0  // Tolerance for medium zoom comparison
-    }
-    
-    // Distance filter values (meters)
-    private enum DistanceFilterValue {
-        static let high: Double = 5.0   // High speed + close zoom
-        static let low: Double = 50.0   // Low speed + far zoom
-        static let medium: Double = 10.0 // Medium conditions
-    }
-    
     /// テスト用: 現在位置を設定できるプロパティ
     var currentLocation: CLLocation?
     
@@ -49,36 +26,22 @@ class MockLocationManager: LocationManagerProtocol {
         isUpdatingLocation = false
     }
     
-    func adjustUpdateFrequency(forSpeed speed: Double, zoomDistance: Double) {
-        // 速度とズームレベルに基づいてdistanceFilterを計算
-        // 高速 + 近いズーム = 頻繁な更新（小さいdistanceFilter）
-        // 低速 + 遠いズーム = 少ない更新（大きいdistanceFilter）
+    func adjustUpdateFrequency(forZoomLevel zoomLevel: Double) {
+        // ズームレベルに基づいてdistanceFilterを計算
+        // ズームインしているほど細かく更新（小さいdistanceFilter）
         
-        // テストケースに基づいた実装：
-        // - 高速(60km/h) + 近いズーム(500m) = 5m
-        // - 低速(10km/h) + 遠いズーム(5000m) = 50m
-        // - 中速(30km/h) + 中間ズーム(1000m) = 10m
-        
-        if speed >= SpeedThreshold.high && zoomDistance <= ZoomThreshold.close {
-            // 高速 + 近いズーム
-            distanceFilter = DistanceFilterValue.high
-        } else if speed <= SpeedThreshold.low && zoomDistance >= ZoomThreshold.far {
-            // 低速 + 遠いズーム
-            distanceFilter = DistanceFilterValue.low
-        } else if abs(speed - SpeedThreshold.medium) < SpeedThreshold.tolerance && 
-                  abs(zoomDistance - ZoomThreshold.medium) < ZoomThreshold.tolerance {
-            // 中速 + 中間ズーム
-            distanceFilter = DistanceFilterValue.medium
+        if zoomLevel >= 16 {
+            // 非常に詳細なズーム
+            distanceFilter = 5.0
+        } else if zoomLevel >= 14 {
+            // 詳細なズーム
+            distanceFilter = 10.0
+        } else if zoomLevel >= 12 {
+            // 標準的なズーム
+            distanceFilter = 20.0
         } else {
-            // その他の場合は速度とズームに基づいて計算
-            let speedFactor = min(max(speed / 60.0, 0.1), 1.0) // 0.1 ~ 1.0 に正規化
-            let zoomFactor = min(max(zoomDistance / 5000.0, 0.1), 1.0) // 0.1 ~ 1.0 に正規化
-            
-            // 逆相関：速度が速くズームが近いほど小さい値
-            let combinedFactor = 1.0 - (speedFactor * (1.0 - zoomFactor))
-            
-            // 5m ~ 50m の範囲で調整
-            distanceFilter = 5.0 + (combinedFactor * 45.0)
+            // 広域ズーム
+            distanceFilter = 50.0
         }
     }
     

--- a/Tests/JustAMapTests/MockLocationManager.swift
+++ b/Tests/JustAMapTests/MockLocationManager.swift
@@ -26,21 +26,21 @@ class MockLocationManager: LocationManagerProtocol {
         isUpdatingLocation = false
     }
     
-    func adjustUpdateFrequency(forZoomLevel zoomLevel: Double) {
-        // ズームレベルに基づいてdistanceFilterを計算
-        // ズームインしているほど細かく更新（小さいdistanceFilter）
+    func adjustUpdateFrequency(forAltitude altitude: Double) {
+        // カメラの高度に基づいてdistanceFilterを計算
+        // 高度が低いほど（ズームインしているほど）細かく更新（小さいdistanceFilter）
         
-        if zoomLevel >= 16 {
-            // 非常に詳細なズーム
+        if altitude <= 500 {
+            // 非常に詳細なズーム（街区レベル以下）
             distanceFilter = 5.0
-        } else if zoomLevel >= 14 {
-            // 詳細なズーム
+        } else if altitude <= 2000 {
+            // 詳細なズーム（地区レベル以下）
             distanceFilter = 10.0
-        } else if zoomLevel >= 12 {
-            // 標準的なズーム
+        } else if altitude <= 10000 {
+            // 標準的なズーム（市レベル以下）
             distanceFilter = 20.0
         } else {
-            // 広域ズーム
+            // 広域ズーム（市レベルより広域）
             distanceFilter = 50.0
         }
     }

--- a/doc/swiftui-mapkit-rotation-limitations.md
+++ b/doc/swiftui-mapkit-rotation-limitations.md
@@ -75,7 +75,7 @@ Map(position: $mapPosition, interactionModes: viewModel.mapControlsViewModel.isN
 
 ### 3. 頻繁な位置更新による滑らかさの改善
 
-速度とズームレベルに基づいて位置情報の更新頻度を動的に調整することで、ある程度の滑らかさを実現。
+カメラの高度（ズームレベル）に基づいて位置情報の更新頻度を動的に調整することで、ある程度の滑らかさを実現。
 
 ## 推奨される解決策
 


### PR DESCRIPTION
## Summary
- 位置情報更新頻度の調整を速度ベースから高度（ズームレベル）ベースに変更
- より直感的な動作：詳細表示時は細かく更新、広域表示時は粗く更新
- Issue #76 を解決

## Changes
- `adjustUpdateFrequency` メソッドのパラメータを速度から高度に変更
- 高度に基づく更新頻度の実装：
  - 500m以下（街区レベル）: 5m移動で更新
  - 2000m以下（地区レベル）: 10m移動で更新
  - 10000m以下（市レベル）: 20m移動で更新
  - それ以上（広域）: 50m移動で更新

## Test plan
- [x] 既存のテストが全て通過することを確認
- [x] 新しい高度ベースのテストケースを追加
- [ ] 実機でズームイン/アウト時の位置更新頻度を確認

Fixes #76