### PR TITLE
fix: 速度表示が停止時に0にならない問題を修正

### DIFF
--- a/Sources/JustAMap/MapView.swift
+++ b/Sources/JustAMap/MapView.swift
@@ -308,6 +308,8 @@ struct MapView: View {
                 .onDisappear {
                     // 設定画面が閉じられたときに住所フォーマットを更新
                     viewModel.refreshAddressFormat()
+                    // 速度表示設定が変更された可能性があるので更新
+                    viewModel.updateSpeedDisplaySetting()
                 }
         }
     }

--- a/Sources/JustAMap/Models/LocationManager.swift
+++ b/Sources/JustAMap/Models/LocationManager.swift
@@ -21,7 +21,8 @@ class LocationManager: NSObject, LocationManagerProtocol {
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
         locationManager.distanceFilter = 10.0 // 10メートル移動したら更新
         locationManager.allowsBackgroundLocationUpdates = false
-        locationManager.pausesLocationUpdatesAutomatically = true
+        // Note: pausesLocationUpdatesAutomatically will be set dynamically based on speed display setting
+        locationManager.pausesLocationUpdatesAutomatically = true // デフォルトはtrue（バッテリー効率優先）
         locationManager.activityType = .automotiveNavigation // バイク走行を想定
     }
     
@@ -85,6 +86,14 @@ class LocationManager: NSObject, LocationManagerProtocol {
         if abs(locationManager.distanceFilter - newDistanceFilter) > 2.0 {
             locationManager.distanceFilter = newDistanceFilter
         }
+    }
+    
+    func updatePausesLocationUpdatesAutomatically(for settings: MapSettingsStorageProtocol) {
+        // 速度表示がONの場合は、pausesLocationUpdatesAutomaticallyをfalseに設定
+        // これにより、停止時でも位置情報更新が継続され、速度が正しく0になる
+        // 速度表示がOFFの場合は、pausesLocationUpdatesAutomaticallyをtrueに設定
+        // これにより、バッテリー効率を優先する
+        locationManager.pausesLocationUpdatesAutomatically = !settings.isSpeedDisplayEnabled
     }
 }
 

--- a/Sources/JustAMap/Models/LocationManagerProtocol.swift
+++ b/Sources/JustAMap/Models/LocationManagerProtocol.swift
@@ -22,6 +22,10 @@ protocol LocationManagerProtocol: AnyObject {
     /// カメラの高度に基づいて更新頻度を調整
     /// - Parameter altitude: 地図カメラの高度（メートル）
     func adjustUpdateFrequency(forAltitude altitude: Double)
+    
+    /// 速度表示設定に基づいてpausesLocationUpdatesAutomaticallyを更新
+    /// - Parameter settings: 地図設定ストレージ
+    func updatePausesLocationUpdatesAutomatically(for settings: MapSettingsStorageProtocol)
 }
 
 /// LocationManagerのイベントを受け取るデリゲート

--- a/Sources/JustAMap/Models/MapViewModel.swift
+++ b/Sources/JustAMap/Models/MapViewModel.swift
@@ -63,6 +63,9 @@ class MapViewModel: ObservableObject {
         
         // 保存された設定を読み込む
         loadSettings()
+        
+        // 速度表示設定に基づいてpausesLocationUpdatesAutomaticallyを設定
+        locationManager.updatePausesLocationUpdatesAutomatically(for: settingsStorage)
     }
     
     private func loadSettings() {
@@ -129,6 +132,12 @@ class MapViewModel: ObservableObject {
             lastGeocodedLocation = nil
             fetchAddress(for: location)
         }
+    }
+    
+    /// 速度表示設定が変更されたときに呼び出される
+    func updateSpeedDisplaySetting() {
+        // 速度表示設定に基づいてpausesLocationUpdatesAutomaticallyを更新
+        locationManager.updatePausesLocationUpdatesAutomatically(for: settingsStorage)
     }
     
     func requestLocationPermission() {

--- a/Tests/JustAMapTests/LocationManagerTests.swift
+++ b/Tests/JustAMapTests/LocationManagerTests.swift
@@ -163,6 +163,32 @@ final class LocationManagerTests: XCTestCase {
         // Then
         XCTAssertTrue(mockDelegate.didResumeLocationUpdates)
     }
+    
+    func testLocationManagerDisablesPausesWhenSpeedDisplayEnabled() {
+        // Given
+        sut = MockLocationManager()
+        let mockSettings = MockMapSettingsStorage()
+        mockSettings.isSpeedDisplayEnabled = true
+        
+        // When
+        (sut as! MockLocationManager).updatePausesLocationUpdatesAutomatically(for: mockSettings)
+        
+        // Then
+        XCTAssertFalse((sut as! MockLocationManager).pausesLocationUpdatesAutomatically)
+    }
+    
+    func testLocationManagerEnablesPausesWhenSpeedDisplayDisabled() {
+        // Given
+        sut = MockLocationManager()
+        let mockSettings = MockMapSettingsStorage()
+        mockSettings.isSpeedDisplayEnabled = false
+        
+        // When
+        (sut as! MockLocationManager).updatePausesLocationUpdatesAutomatically(for: mockSettings)
+        
+        // Then
+        XCTAssertTrue((sut as! MockLocationManager).pausesLocationUpdatesAutomatically)
+    }
 }
 
 // MARK: - Mock Delegate

--- a/Tests/JustAMapTests/MapViewModelTests.swift
+++ b/Tests/JustAMapTests/MapViewModelTests.swift
@@ -428,4 +428,24 @@ final class MapViewModelTests: XCTestCase {
         XCTAssertEqual(sut.currentSpeed, 15.0, "位置情報更新が再開した場合、速度が更新されるべき")
     }
     
+    func testUpdateSpeedDisplaySetting() async throws {
+        // Given - 速度表示設定がOFFの状態
+        mockSettingsStorage.isSpeedDisplayEnabled = false
+        
+        // When - 速度表示設定の更新を呼び出す
+        sut.updateSpeedDisplaySetting()
+        
+        // Then - LocationManagerのupdatePausesLocationUpdatesAutomaticallyが呼ばれるべき
+        XCTAssertTrue(mockLocationManager.pausesLocationUpdatesAutomatically, "速度表示OFFの場合、pausesLocationUpdatesAutomaticallyはtrueであるべき")
+        
+        // Given - 速度表示設定をONに変更
+        mockSettingsStorage.isSpeedDisplayEnabled = true
+        
+        // When - 速度表示設定の更新を呼び出す
+        sut.updateSpeedDisplaySetting()
+        
+        // Then - LocationManagerのpausesLocationUpdatesAutomaticallyがfalseになるべき
+        XCTAssertFalse(mockLocationManager.pausesLocationUpdatesAutomatically, "速度表示ONの場合、pausesLocationUpdatesAutomaticallyはfalseであるべき")
+    }
+    
 }

--- a/Tests/JustAMapTests/MockLocationManager.swift
+++ b/Tests/JustAMapTests/MockLocationManager.swift
@@ -10,6 +10,7 @@ class MockLocationManager: LocationManagerProtocol {
     private(set) var didRequestAuthorization = false
     private(set) var isUpdatingLocation = false
     private(set) var distanceFilter: Double = 10.0
+    private(set) var pausesLocationUpdatesAutomatically: Bool = true
     
     /// テスト用: 現在位置を設定できるプロパティ
     var currentLocation: CLLocation?
@@ -71,5 +72,10 @@ class MockLocationManager: LocationManagerProtocol {
     /// テスト用: 位置情報更新の再開をシミュレート
     func simulateLocationUpdatesResumed() {
         delegate?.locationManagerDidResumeLocationUpdates(self)
+    }
+    
+    /// テスト用: 速度表示設定に基づいてpausesLocationUpdatesAutomaticallyを更新
+    func updatePausesLocationUpdatesAutomatically(for settings: MapSettingsStorageProtocol) {
+        pausesLocationUpdatesAutomatically = !settings.isSpeedDisplayEnabled
     }
 }


### PR DESCRIPTION
## 概要

Issue #81 で報告された、速度表示が停止時に0 km/hにならない問題を修正しました。

## 変更内容

- LocationManagerにpausesLocationUpdatesAutomaticallyの動的切り替え機能を追加
- 速度表示がONの場合: pausesLocationUpdatesAutomatically = false（常に位置情報更新）
- 速度表示がOFFの場合: pausesLocationUpdatesAutomatically = true（バッテリー効率優先）
- MapViewModelに速度表示設定更新メソッドを追加
- 設定画面が閉じられた時に速度表示設定を更新するよう変更
- TDDアプローチでテストを追加

Fixes #81

🤖 Generated with [Claude Code](https://claude.ai/code)