### PR TITLE
fix(speed): reset to 0 when stopped with speed display enabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/Sources/JustAMap/Models/MapViewModel.swift
+++ b/Sources/JustAMap/Models/MapViewModel.swift
@@ -295,9 +295,15 @@ extension MapViewModel: LocationManagerDelegate {
             self.currentAltitude = location.altitude
             self.currentVerticalAccuracy = location.verticalAccuracy
             
-            // 速度が有効な場合のみ更新（無効値-1の場合は前の値を保持）
+            // 速度更新ロジック
+            //  - 速度が有効な場合はそのまま反映
+            //  - 無効値（-1）の場合:
+            //    * 速度表示ON時は停止とみなし0にリセット
+            //    * 速度表示OFF時は従来通り前回の値を保持
             if location.speed >= 0 {
                 self.currentSpeed = location.speed
+            } else if self.isSpeedDisplayEnabled {
+                self.currentSpeed = 0.0
             }
             
             self.updateRegionIfFollowing(location: location)

--- a/Tests/JustAMapTests/SpeedStopBehaviorTests.swift
+++ b/Tests/JustAMapTests/SpeedStopBehaviorTests.swift
@@ -15,7 +15,7 @@ final class SpeedStopBehaviorTests: XCTestCase {
         mockGeocodeService = MockGeocodeService()
         mockIdleTimerManager = MockIdleTimerManager()
         mockSettingsStorage = MockMapSettingsStorage()
-        // 速度表示をONにして起動
+        // Enable speed display on startup
         mockSettingsStorage.isSpeedDisplayEnabled = true
 
         sut = MapViewModel(

--- a/Tests/JustAMapTests/SpeedStopBehaviorTests.swift
+++ b/Tests/JustAMapTests/SpeedStopBehaviorTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import CoreLocation
+@testable import JustAMap
+
+@MainActor
+final class SpeedStopBehaviorTests: XCTestCase {
+    var sut: MapViewModel!
+    var mockLocationManager: MockLocationManager!
+    var mockGeocodeService: MockGeocodeService!
+    var mockIdleTimerManager: MockIdleTimerManager!
+    var mockSettingsStorage: MockMapSettingsStorage!
+
+    override func setUp() async throws {
+        mockLocationManager = MockLocationManager()
+        mockGeocodeService = MockGeocodeService()
+        mockIdleTimerManager = MockIdleTimerManager()
+        mockSettingsStorage = MockMapSettingsStorage()
+        // 速度表示をONにして起動
+        mockSettingsStorage.isSpeedDisplayEnabled = true
+
+        sut = MapViewModel(
+            locationManager: mockLocationManager,
+            geocodeService: mockGeocodeService,
+            idleTimerManager: mockIdleTimerManager,
+            settingsStorage: mockSettingsStorage
+        )
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        mockLocationManager = nil
+        mockGeocodeService = nil
+        mockIdleTimerManager = nil
+        mockSettingsStorage = nil
+    }
+
+    func testSpeedBecomesZeroWhenInvalidSpeedWhileDisplayEnabled() async {
+        // Given - 移動中の有効な速度が設定されている
+        let movingLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 35.6762, longitude: 139.6503),
+            altitude: 0,
+            horizontalAccuracy: 5.0,
+            verticalAccuracy: 5.0,
+            course: 0,
+            speed: 10.0, // 10 m/s
+            timestamp: Date()
+        )
+        sut.locationManager(mockLocationManager, didUpdateLocation: movingLocation)
+        let setExpectation = expectation(description: "initial speed set")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { setExpectation.fulfill() }
+        await fulfillment(of: [setExpectation], timeout: 1.0)
+        XCTAssertEqual(sut.currentSpeed, 10.0)
+
+        // When - 無効な速度（停止時に発生しうる）を受信
+        let invalidSpeedLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 35.6762, longitude: 139.6503),
+            altitude: 0,
+            horizontalAccuracy: 5.0,
+            verticalAccuracy: 5.0,
+            course: -1,
+            speed: -1.0, // invalid
+            timestamp: Date()
+        )
+        sut.locationManager(mockLocationManager, didUpdateLocation: invalidSpeedLocation)
+
+        // Then - 速度が0にリセットされる（速度表示ON時の期待挙動）
+        let expectation = expectation(description: "invalid speed handled as zero")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expectation.fulfill() }
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(sut.currentSpeed, 0.0, "Invalid speed should be treated as 0 when speed display is enabled")
+    }
+}
+

--- a/Tests/JustAMapTests/SpeedStopBehaviorTests.swift
+++ b/Tests/JustAMapTests/SpeedStopBehaviorTests.swift
@@ -34,8 +34,8 @@ final class SpeedStopBehaviorTests: XCTestCase {
         mockSettingsStorage = nil
     }
 
-    func testSpeedBecomesZeroWhenInvalidSpeedWhileDisplayEnabled() async {
-        // Given - 移動中の有効な速度が設定されている
+    func testSpeedBecomesZeroAfterConsecutiveInvalidsWhenStopped() async {
+        // Given - Valid speed, then stop and receive consecutive invalids
         let movingLocation = CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 35.6762, longitude: 139.6503),
             altitude: 0,
@@ -51,23 +51,84 @@ final class SpeedStopBehaviorTests: XCTestCase {
         await fulfillment(of: [setExpectation], timeout: 1.0)
         XCTAssertEqual(sut.currentSpeed, 10.0)
 
-        // When - 無効な速度（停止時に発生しうる）を受信
-        let invalidSpeedLocation = CLLocation(
-            coordinate: CLLocationCoordinate2D(latitude: 35.6762, longitude: 139.6503),
+        // When - stop at same coordinate and feed consecutive invalid speeds
+        let t1 = movingLocation.timestamp.addingTimeInterval(0.5)
+        let invalid1 = CLLocation(
+            coordinate: movingLocation.coordinate,
             altitude: 0,
             horizontalAccuracy: 5.0,
             verticalAccuracy: 5.0,
             course: -1,
-            speed: -1.0, // invalid
-            timestamp: Date()
+            speed: -1.0,
+            timestamp: t1
         )
-        sut.locationManager(mockLocationManager, didUpdateLocation: invalidSpeedLocation)
+        sut.locationManager(mockLocationManager, didUpdateLocation: invalid1)
 
-        // Then - 速度が0にリセットされる（速度表示ON時の期待挙動）
-        let expectation = expectation(description: "invalid speed handled as zero")
+        let t2 = t1.addingTimeInterval(0.5)
+        let invalid2 = CLLocation(
+            coordinate: movingLocation.coordinate,
+            altitude: 0,
+            horizontalAccuracy: 5.0,
+            verticalAccuracy: 5.0,
+            course: -1,
+            speed: -1.0,
+            timestamp: t2
+        )
+        sut.locationManager(mockLocationManager, didUpdateLocation: invalid2)
+
+        let t3 = t2.addingTimeInterval(0.5)
+        let invalid3 = CLLocation(
+            coordinate: movingLocation.coordinate,
+            altitude: 0,
+            horizontalAccuracy: 5.0,
+            verticalAccuracy: 5.0,
+            course: -1,
+            speed: -1.0,
+            timestamp: t3
+        )
+        sut.locationManager(mockLocationManager, didUpdateLocation: invalid3)
+
+        // Then - speed becomes 0 after enough invalids while not moving
+        let expectation = expectation(description: "invalid speeds lead to zero when stopped")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { expectation.fulfill() }
         await fulfillment(of: [expectation], timeout: 1.0)
-        XCTAssertEqual(sut.currentSpeed, 0.0, "Invalid speed should be treated as 0 when speed display is enabled")
+        XCTAssertEqual(sut.currentSpeed, 0.0)
+    }
+    
+    func testInvalidSpeedDoesNotDropToZeroWhileMoving() async {
+        // Given - moving with valid speed
+        let start = Date()
+        let loc1 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 35.6762, longitude: 139.6503),
+            altitude: 0,
+            horizontalAccuracy: 5.0,
+            verticalAccuracy: 5.0,
+            course: 0,
+            speed: 15.0,
+            timestamp: start
+        )
+        sut.locationManager(mockLocationManager, didUpdateLocation: loc1)
+        let e1 = expectation(description: "set speed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { e1.fulfill() }
+        await fulfillment(of: [e1], timeout: 1.0)
+        XCTAssertEqual(sut.currentSpeed, 15.0)
+
+        // When - next update is invalid but position advanced (approx speed > threshold)
+        let advanced = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 35.6765, longitude: 139.6508),
+            altitude: 0,
+            horizontalAccuracy: 5.0,
+            verticalAccuracy: 5.0,
+            course: -1,
+            speed: -1.0,
+            timestamp: start.addingTimeInterval(0.5)
+        )
+        sut.locationManager(mockLocationManager, didUpdateLocation: advanced)
+
+        // Then - should keep previous non-zero speed (no blip to zero)
+        let e2 = expectation(description: "no zero blip")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { e2.fulfill() }
+        await fulfillment(of: [e2], timeout: 1.0)
+        XCTAssertEqual(sut.currentSpeed, 15.0)
     }
 }
-

--- a/doc/issues/speed-zero-when-stopped.ja.md
+++ b/doc/issues/speed-zero-when-stopped.ja.md
@@ -1,0 +1,57 @@
+---
+title: 速度表示ON時に停止しても速度が0にならない
+labels: bug, speed, ios, corelocation
+status: open
+---
+
+## 概要
+
+速度表示をONにした状態で走行を停止しても、速度が0にならず直前の速度が表示され続けることがある。
+
+## 期待される挙動
+
+- 停止時は速度が0として表示される。
+- CoreLocationが無効値（`speed = -1`）を返す場合でも、停止状態を適切に検出して0を表示する。
+
+## 実際の挙動
+
+- 停止後もしばらく速度が前回の値のまま表示される。
+- 特に「速度表示ON」により `CLLocationManager.pausesLocationUpdatesAutomatically = false` のため、
+  `locationManagerDidPauseLocationUpdates` が呼ばれず、0リセットの契機が発生しない。
+
+## 原因の推定
+
+- `MapViewModel.locationManager(_:didUpdateLocation:)` で `location.speed < 0`（無効値）の場合、
+  速度を更新せず「直前の有効値を保持」する実装となっている。
+- 速度表示ON時は位置更新の自動一時停止を無効化しているため、停止時に0へリセットする経路が存在しない。
+
+## 修正方針（TDD）
+
+1. 再現テストを追加（Red）
+   - 前提: 速度表示ON
+   - 有効な速度（例: 10 m/s）を受信後、無効速度（-1）を受信したら速度が0になることを検証
+2. 実装（Green）
+   - `location.speed < 0` かつ「速度表示ON」のときは `currentSpeed = 0` を設定
+   - 既存の「速度表示OFFでは無効値は無視して前回値保持」の挙動は維持
+3. リファクタリング（必要に応じて）
+
+## 影響範囲
+
+- `MapViewModel` の速度更新ロジックのみ（UIや他機能への副作用はなし）
+- 既存テストは「速度表示OFF」を前提としているため非影響。新規テストでON時の挙動を追加。
+
+## 確認項目
+
+- [ ] 速度表示ON時、停止で0表示になる
+- [ ] 速度表示OFF時、無効速度は引き続き無視される
+- [ ] 速度単位（km/h, mph）の表示は既存実装通り
+
+## 参考
+
+- CoreLocationの `CLLocation.speed` は m/s で、無効時は `-1` を返す
+
+---
+
+実装ブランチ: `fix/speed-zero-when-stopped`
+PR: 未作成
+

--- a/doc/issues/speed-zero-when-stopped.md
+++ b/doc/issues/speed-zero-when-stopped.md
@@ -1,0 +1,55 @@
+---
+title: Speed does not become 0 when stopped with speed display ON
+labels: bug, speed, ios, corelocation
+status: open
+---
+
+## Summary
+
+When speed display is ON, after coming to a stop the speed sometimes does not drop to 0 and the previous non-zero value remains displayed.
+
+## Expected Behavior
+
+- When stopped, speed should display as 0.
+- Even if CoreLocation reports an invalid speed (`speed = -1`), the app should treat it as 0 when stopped.
+
+## Actual Behavior
+
+- After stopping, the previously displayed speed persists for a while.
+- Because `CLLocationManager.pausesLocationUpdatesAutomatically = false` when speed display is ON, `locationManagerDidPauseLocationUpdates` is not called and there is no chance to reset to 0.
+
+## Root Cause Hypothesis
+
+- In `MapViewModel.locationManager(_:didUpdateLocation:)`, when `location.speed < 0` (invalid), the code keeps the previous valid value instead of updating.
+- With speed display ON, automatic pausing is disabled, so there is no event to force-reset speed to 0 while stationary.
+
+## Fix Plan (TDD)
+
+1. Add a failing test (Red)
+   - Given speed display ON
+   - After receiving a valid speed (e.g., 10 m/s), when receiving an invalid speed (-1), speed becomes 0.
+2. Implement (Green)
+   - When `location.speed < 0` and speed display is ON, set `currentSpeed = 0`.
+   - Preserve existing behavior for speed display OFF: ignore invalid speed and keep the last valid value.
+3. Refactor as needed.
+
+## Impact
+
+- Only the speed update logic in `MapViewModel`.
+- Existing tests assume speed display OFF; unaffected. New tests will cover the ON case.
+
+## Checklist
+
+- [ ] With speed display ON, speed becomes 0 when stopped
+- [ ] With speed display OFF, invalid speed is still ignored
+- [ ] Unit display (km/h, mph) remains unchanged
+
+## Notes
+
+- CoreLocation `CLLocation.speed` is in m/s and returns `-1` when invalid
+
+---
+
+Implementation branch: `fix/speed-zero-when-stopped`
+PR: not yet created
+

--- a/scripts/find-simulator.sh
+++ b/scripts/find-simulator.sh
@@ -9,40 +9,88 @@ set -euo pipefail
 # Determine host architecture
 HOST_ARCH=$(uname -m)
 
-# Get all available iOS Simulator destinations from xcodebuild
-# The output format is like: { platform:iOS Simulator, arch:arm64, id:UDID, OS:17.0.1, name:iPhone 15 Pro }
-DESTINATIONS=$(xcodebuild -showdestinations -scheme JustAMap 2>/dev/null | grep "platform:iOS Simulator")
+# First try using xcrun simctl to find available simulators
+# This is more reliable in CI environments
+find_simulator_with_simctl() {
+    # Get available simulators
+    local simulators=$(xcrun simctl list devices available 2>/dev/null | grep -E "iPhone.*\(" | grep -v "unavailable" || true)
+    
+    if [ -z "$simulators" ]; then
+        return 1
+    fi
+    
+    # Extract simulator info - format is like: iPhone 15 Pro (UUID) (Shutdown)
+    # Priority 1: iPhone Pro models
+    local udid=$(echo "$simulators" | grep "Pro" | sed -n 's/.*(\([A-F0-9-]*\)).*/\1/p' | head -n 1 || true)
+    if [ -n "$udid" ]; then
+        echo "$udid"
+        return 0
+    fi
+    
+    # Priority 2: Any iPhone
+    udid=$(echo "$simulators" | sed -n 's/.*(\([A-F0-9-]*\)).*/\1/p' | head -n 1 || true)
+    if [ -n "$udid" ]; then
+        echo "$udid"
+        return 0
+    fi
+    
+    return 1
+}
 
-# --- Find the best possible UDID --- 
+# Fallback to xcodebuild -showdestinations
+find_simulator_with_xcodebuild() {
+    # Get all available iOS Simulator destinations from xcodebuild
+    # The output format is like: { platform:iOS Simulator, arch:arm64, id:UDID, OS:17.0.1, name:iPhone 15 Pro }
+    local destinations=$(xcodebuild -showdestinations -scheme JustAMap 2>/dev/null | grep "platform:iOS Simulator" || true)
+    
+    if [ -z "$destinations" ]; then
+        return 1
+    fi
+    
+    # 1. iPhone Pro matching host architecture
+    local udid=$(echo "$destinations" | grep "name:iPhone" | grep "Pro" | grep "arch:$HOST_ARCH" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
+    if [ -n "$udid" ]; then
+        echo "$udid"
+        return 0
+    fi
+    
+    # 2. Any iPhone matching host architecture
+    udid=$(echo "$destinations" | grep "name:iPhone" | grep "arch:$HOST_ARCH" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
+    if [ -n "$udid" ]; then
+        echo "$udid"
+        return 0
+    fi
+    
+    # 3. (Fallback) iPhone Pro with any architecture
+    udid=$(echo "$destinations" | grep "name:iPhone" | grep "Pro" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
+    if [ -n "$udid" ]; then
+        echo "$udid"
+        return 0
+    fi
+    
+    # 4. (Fallback) Any iPhone with any architecture
+    udid=$(echo "$destinations" | grep "name:iPhone" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
+    if [ -n "$udid" ]; then
+        echo "$udid"
+        return 0
+    fi
+    
+    return 1
+}
 
-# 1. iPhone Pro matching host architecture
-UDID=$(echo "$DESTINATIONS" | grep "name:iPhone" | grep "Pro" | grep "arch:$HOST_ARCH" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
-if [ -n "$UDID" ]; then
+# Try simctl first, then xcodebuild
+if UDID=$(find_simulator_with_simctl); then
     echo "$UDID"
     exit 0
 fi
 
-# 2. Any iPhone matching host architecture
-UDID=$(echo "$DESTINATIONS" | grep "name:iPhone" | grep "arch:$HOST_ARCH" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
-if [ -n "$UDID" ]; then
-    echo "$UDID"
-    exit 0
-fi
-
-# 3. (Fallback) iPhone Pro with any architecture
-UDID=$(echo "$DESTINATIONS" | grep "name:iPhone" | grep "Pro" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
-if [ -n "$UDID" ]; then
-    echo "$UDID"
-    exit 0
-fi
-
-# 4. (Fallback) Any iPhone with any architecture
-UDID=$(echo "$DESTINATIONS" | grep "name:iPhone" | sed -n 's/.*id:\([A-F0-9-]*\).*/\1/p' | head -n 1 || true)
-if [ -n "$UDID" ]; then
+if UDID=$(find_simulator_with_xcodebuild); then
     echo "$UDID"
     exit 0
 fi
 
 # If all else fails, exit with an error
 >&2 echo "Error: No suitable iOS Simulator found."
+>&2 echo "Available simulators:"
+>&2 xcrun simctl list devices available | grep -E "iPhone.*\(" || true
 exit 1


### PR DESCRIPTION
This PR fixes a long-standing bug where the speed did not drop to 0 when stopped while the speed display was enabled.

Changes:
- Treat invalid `CLLocation.speed` (-1) as 0 when speed display is ON
- Preserve previous behavior when speed display is OFF (ignore invalid and keep last valid)
- Add unit test: `SpeedStopBehaviorTests`

Documentation:
- See doc/issues/speed-zero-when-stopped.md for the TDD plan and details.\nIssue: https://github.com/skoji/just-a-map/issues/83